### PR TITLE
type coneversion to float when checking adcgain 

### DIFF
--- a/wfdb/_rdsamp.py
+++ b/wfdb/_rdsamp.py
@@ -256,7 +256,7 @@ def readheader(recordname):  # For reading signal headers
                 skew = '0'
             if not byteoffset:
                 byteoffset = '0'
-            if not adcgain:
+            if not float(adcgain):
                 adcgain = '200'
             if not baseline:
                 if not adczero:


### PR DESCRIPTION
 for condition 
if adcgain =0 ; then
    adcgain=200

adcgain is returned as string and therefore type conversion to float is needed when checking for a 0 value