### PR TITLE
HOTFIX: a lonely line threw made the package to throw a warning upon import

### DIFF
--- a/wfdb/readwrite/_signals.py
+++ b/wfdb/readwrite/_signals.py
@@ -1024,7 +1024,7 @@ def digi_nan(fmt):
 
 
 
-reslevels = np.power(2, np.arange(0,33))
+
 def estres(signals):
     """
     def estres(signals):
@@ -1034,6 +1034,7 @@ def estres(signals):
     - signals: A 2d numpy array representing a uniform multichannel signal, or a list of 1d numpy arrays
       representing multiple channels of signals with different numbers of samples per frame.
     """
+    reslevels = np.power(2, np.arange(0,33)) # This has to be corrected as it throws an error
     
     # Expanded sample signals. List of numpy arrays                
     if type(signals) == list:


### PR DESCRIPTION
Put the 1027th line (`reslevels = np.power(2, np.arange(0,33))`) within the `estres` function, as it made the package to throw a warning upon import. However, this line still throws an error and probably has to be fixed.