### PR TITLE
UnicodeDecodeError when downloading mghdb

### DIFF
--- a/wfdb/readwrite/downloads.py
+++ b/wfdb/readwrite/downloads.py
@@ -15,7 +15,7 @@ def streamheader(recordname, pbdir):
     r.raise_for_status()
 
     # Get each line as a string
-    filelines = r.content.decode('ascii').splitlines()
+    filelines = r.content.decode('iso-8859-1').splitlines()
 
     # Separate content into header and comment lines
     headerlines = []


### PR DESCRIPTION
Downloading the mghdb give the following error:
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe1 in position 1209: ordinal not in range(128)

    import wfdb
    wfdb.dldatabase('mghdb', os.getcwd(), records = 'all', annotators = 'all' , keepsubdirs = True, overwrite = False)

It s look like text isn t just ascii, but latin 1.