### PR TITLE
signal name and unit as strings. fixes #168.

### DIFF
--- a/wfdb/plot/plot.py
+++ b/wfdb/plot/plot.py
@@ -428,8 +428,8 @@ def get_wfdb_plot_items(record, annotation, plot_sym):
             raise ValueError('The record has no signal to plot')
 
         fs = record.fs
-        sig_name = record.sig_name
-        sig_units = record.units
+        sig_name = [str(s) for s in record.sig_name]
+        sig_units = [str(s) for s in record.units]
         record_name = 'Record: %s' % record.record_name
         ylabel = ['/'.join(pair) for pair in zip(sig_name, sig_units)]
     else:


### PR DESCRIPTION
"Demo 7" in the sample notebook raises a type error (https://github.com/MIT-LCP/wfdb-python/issues/168) because `sig_units` contains None:

```
(Pdb) sig_name
['II', 'V', 'MCL1', 'ABP']

(Pdb) sig_units
[None, 'mV', 'mV', None]
```

The error is raised when `sig_name` or `sig_units` are not strings (e.g. int or null). This fixes the error.