### PR TITLE
fix: calc sens correctly and remove erroneously labeled FPR

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -120,4 +120,3 @@ class test_qrs():
 
         assert comparitor.sensitivity > 0.99
         assert comparitor.positive_predictivity > 0.99
-        assert comparitor.false_positive_rate < 0.01


### PR DESCRIPTION
addresses #151 and #182 

- sensitivity correctly calculated as TP / (TP+FN)
- PPV correctly calculated as TP / (TP + FP)
- removed "false positive rate" as that is commonly accepted to be 1 - specificity, which was not calculated by the function