### PR TITLE
Fixes URL path issues #166

### DIFF
--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -1573,7 +1573,7 @@ def dl_database(db_dir, dl_dir, records='all', annotators='all',
     ----------
     db_dir : str
         The Physiobank database directory to download. eg. For database:
-        'http://physionet.org/physiobank/database/mitdb', db_dir='mitdb'.
+        'http://physionet.org/physiobank/database/mitdb/', db_dir='mitdb'.
     dl_dir : str
         The full local directory path in which to download the files.
     records : list, or 'all', optional
@@ -1610,7 +1610,7 @@ def dl_database(db_dir, dl_dir, records='all', annotators='all',
 
     """
     # Full url physiobank database
-    db_url = posixpath.join(download.config.db_index_url, db_dir)
+    db_url = posixpath.join(download.config.db_index_url, db_dir) + os.sep
     # Check if the database is valid
     r = requests.get(db_url)
     r.raise_for_status()


### PR DESCRIPTION
Fixes the URL path issue in `wfdb.dl_database` to include a trailing slash to prevent an "HTTPError: 404 Client Error". This has been noted in both issues #166 and #174.