### PR TITLE
Fixes _wfdb_fmt #148

### DIFF
--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -1551,7 +1551,7 @@ def _wfdb_fmt(bit_res, single_fmt=True):
         if single_fmt:
             bit_res = [max(bit_res)] * len(bit_res)
 
-        return [wfdb_fmt(r) for r in bit_res]
+        return [_wfdb_fmt(r) for r in bit_res]
 
     if bit_res <= 8:
         return '80'


### PR DESCRIPTION
Fixes the call of the function `_wfdb_fmt` inside of the `_wfdb_fmt` function of the `_signal.py` file.