### PR TITLE
Adds more to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+.vscode
+venv/
 env/
 build/
 develop-eggs/


### PR DESCRIPTION
Adds more to `.gitignore` for VS Code users as well as users who name their virtual environment "venv" instead of "env"