### PR TITLE
Fixes ReadTheDocs build error

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ class Mock(MagicMock):
             return MagicMock()
 
 MOCK_MODULES = ['numpy', 'matplotlib', 'matplotlib.pyplot', 'pandas', 'scipy',
-                'sklearn', 'sklearn.preprocessing', 'requests', 'mne']
+                'sklearn', 'sklearn.preprocessing', 'mne']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
Fixes ImportError with ReadTheDocs where `requests` can't be imported.. probably because it is already being mock imported.