### PR TITLE
updated regex to correctly parse units

### DIFF
--- a/wfdb/io/_header.py
+++ b/wfdb/io/_header.py
@@ -107,7 +107,7 @@ _rx_signal = re.compile(''.join(
     ["(?P<file_name>~?[-\w]*\.?[\w]*)[ \t]+(?P<fmt>\d+)x?"
      "(?P<samps_per_frame>\d*):?(?P<skew>\d*)\+?(?P<byte_offset>\d*)[ \t]*",
      "(?P<adc_gain>-?\d*\.?\d*e?[\+-]?\d*)\(?(?P<baseline>-?\d*)\)?",
-     "/?(?P<units>[\w\^\-\?%]*)[ \t]*(?P<adc_res>\d*)[ \t]*",
+     "/?(?P<units>[\w\^\-\?%\/]*)[ \t]*(?P<adc_res>\d*)[ \t]*",
      "(?P<adc_zero>-?\d*)[ \t]*(?P<init_value>-?\d*)[ \t]*(?P<checksum>-?\d*)",
      "[ \t]*(?P<block_size>\d*)[ \t]*(?P<sig_name>[\S]?[^\t\n\r\f\v]*)"])
 )


### PR DESCRIPTION
Fixes #231 

with the change the output is
```
        sig_name   units  adc_res  init_value  checksum  block_size
0           Chin      uV       15           0     24244           0
1       Left Leg      uV       15           0     22989           0
2      Right Leg      uV       15           0    -22154           0
3  CPAP Pressure  mcmH2O       15           0    -24985           0
4      CPAP Flow   l/min       15           0    -22447           0
5      CPAP Leak   l/min       15           0     10563           0
6       Light_BU       m       15           0     17314           0
7       XFlow_DR    mV/s       15           0    -12675           0
```