### PR TITLE
Adds original signame function

### DIFF
--- a/wfdb/__init__.py
+++ b/wfdb/__init__.py
@@ -1,5 +1,5 @@
 from .io.record import (Record, MultiRecord, rdheader, rdrecord, rdsamp,
-                        wrsamp, dl_database, edf2mit)
+                        wrsamp, dl_database, edf2mit, signame)
 from .io.annotation import (Annotation, rdann, wrann, show_ann_labels,
                             show_ann_classes)
 from .io.download import get_dbs, get_record_list, dl_files, set_db_index_url

--- a/wfdb/__init__.py
+++ b/wfdb/__init__.py
@@ -1,5 +1,6 @@
 from .io.record import (Record, MultiRecord, rdheader, rdrecord, rdsamp,
-                        wrsamp, dl_database, edf2mit, signame)
+                        wrsamp, dl_database, edf2mit, sampfreq, signame)
+
 from .io.annotation import (Annotation, rdann, wrann, show_ann_labels,
                             show_ann_classes)
 from .io.download import get_dbs, get_record_list, dl_files, set_db_index_url

--- a/wfdb/io/__init__.py
+++ b/wfdb/io/__init__.py
@@ -1,5 +1,5 @@
 from .record import (Record, MultiRecord, rdheader, rdrecord, rdsamp, wrsamp,
-                     dl_database, edf2mit, SIGNAL_CLASSES)
+                     dl_database, edf2mit, signame, SIGNAL_CLASSES)
 from ._signal import est_res, wr_dat_file
 from .annotation import (Annotation, rdann, wrann, show_ann_labels,
                          show_ann_classes)

--- a/wfdb/io/__init__.py
+++ b/wfdb/io/__init__.py
@@ -1,5 +1,6 @@
 from .record import (Record, MultiRecord, rdheader, rdrecord, rdsamp, wrsamp,
-                     dl_database, edf2mit, signame, SIGNAL_CLASSES)
+                     dl_database, edf2mit, sampfreq, signame, SIGNAL_CLASSES)
+
 from ._signal import est_res, wr_dat_file
 from .annotation import (Annotation, rdann, wrann, show_ann_labels,
                          show_ann_classes)

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -2014,6 +2014,55 @@ def rdsamp(record_name, sampfrom=0, sampto=None, channels=None, pn_dir=None,
     return signals, fields
 
 
+def sampfreq(record_name, pn_dir=None):
+    """
+    Read a WFDB header file and return the sampling frequency of
+    each of the signals in the record.
+
+    Parameters
+    ----------
+    record_name : str
+        The name of the WFDB record to be read, without any file
+        extensions. If the argument contains any path delimiter
+        characters, the argument will be interpreted as PATH/BASE_RECORD.
+        Both relative and absolute paths are accepted. If the `pn_dir`
+        parameter is set, this parameter should contain just the base
+        record name, and the files fill be searched for remotely.
+        Otherwise, the data files will be searched for in the local path.
+    pn_dir : str, optional
+        Option used to stream data from Physionet. The Physionet
+        database directory from which to find the required record files.
+        eg. For record '100' in 'http://physionet.org/content/mitdb'
+        pn_dir='mitdb'.
+    sig_nums : list, optional
+        A list of the signal numbers to be outputted.
+
+    Returns
+    -------
+    N/A
+
+    Examples
+    --------
+    >>> wfdb.sampfreq('sample-data/test01_00s')
+    >>> ECG 1    500
+    >>> ECG 2    500
+    >>> ECG 3    500
+    >>> ECG 4    500
+
+    """
+    if (pn_dir is not None) and ('.' not in pn_dir):
+        dir_list = pn_dir.split(os.sep)
+        pn_dir = posixpath.join(dir_list[0], get_version(dir_list[0]),
+                                *dir_list[1:])
+
+    record = rdheader(record_name, pn_dir=pn_dir)
+    samps_per_frame = [record.fs*samp for samp in record.samps_per_frame]
+    sig_name = record.sig_name
+
+    for sig,samp in zip(sig_name, samps_per_frame):
+        print('{}\t{}'.format(sig,samp))
+
+
 def signame(record_name, pn_dir=None, sig_nums=[]):
     """
     Read a WFDB record file and return the signal names.
@@ -2033,8 +2082,6 @@ def signame(record_name, pn_dir=None, sig_nums=[]):
         database directory from which to find the required record files.
         eg. For record '100' in 'http://physionet.org/content/mitdb'
         pn_dir='mitdb'.
-    sig_nums : list, optional
-        A list of the signal numbers to be outputted.
 
     Returns
     -------

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -2014,6 +2014,61 @@ def rdsamp(record_name, sampfrom=0, sampto=None, channels=None, pn_dir=None,
     return signals, fields
 
 
+def signame(record_name, pn_dir=None, sig_nums=[]):
+    """
+    Read a WFDB record file and return the signal names.
+
+    Parameters
+    ----------
+    record_name : str
+        The name of the WFDB record to be read, without any file
+        extensions. If the argument contains any path delimiter
+        characters, the argument will be interpreted as PATH/BASE_RECORD.
+        Both relative and absolute paths are accepted. If the `pn_dir`
+        parameter is set, this parameter should contain just the base
+        record name, and the files fill be searched for remotely.
+        Otherwise, the data files will be searched for in the local path.
+    pn_dir : str, optional
+        Option used to stream data from Physionet. The Physionet
+        database directory from which to find the required record files.
+        eg. For record '100' in 'http://physionet.org/content/mitdb'
+        pn_dir='mitdb'.
+    sig_nums : list, optional
+        A list of the signal numbers to be outputted.
+
+    Returns
+    -------
+    N/A
+
+    Examples
+    --------
+    >>> wfdb.signame('sample-data/test01_00s')
+    >>> ECG 1
+    >>> ECG 2
+    >>> ECG 3
+    >>> ECG 4
+
+    >>> wfdb.signame('sample-data/test01_00s', sig_nums=[1,3])
+    >>> ECG 2
+    >>> ECG 4
+
+    """
+    if (pn_dir is not None) and ('.' not in pn_dir):
+        dir_list = pn_dir.split(os.sep)
+        pn_dir = posixpath.join(dir_list[0], get_version(dir_list[0]),
+                                 *dir_list[1:])
+
+    record = rdheader(record_name, pn_dir=pn_dir)
+    if len(sig_nums) > 0:
+        for n in sig_nums:
+            try:
+                print(record.sig_name[n])
+            except IndexError:
+                raise Exception('sig_nums value {} out of range'.format(n))
+    else:
+        print(*record.sig_name, sep='\n')
+
+
 def _get_wanted_channels(wanted_sig_names, record_sig_names, pad=False):
     """
     Given some wanted signal names, and the signal names contained in a


### PR DESCRIPTION
Adds the `signame` function from the [original WFDB software package](https://www.physionet.org/physiotools/wag/signam-1.htm). This version maintains the original functionality including the `-s` option for specific signal numbers. Since the `-h` option just prints help for the function, this was omitted since it can be recreated using `help(wfdb.signame)`.