### PR TITLE
Adds original ann2rr function

### DIFF
--- a/wfdb/__init__.py
+++ b/wfdb/__init__.py
@@ -1,7 +1,7 @@
 from .io.record import (Record, MultiRecord, rdheader, rdrecord, rdsamp,
                         wrsamp, dl_database, edf2mit, sampfreq, signame)
 from .io.annotation import (Annotation, rdann, wrann, show_ann_labels,
-                            show_ann_classes)
+                            show_ann_classes, ann2rr)
 from .io.download import get_dbs, get_record_list, dl_files, set_db_index_url
 from .plot.plot import plot_items, plot_wfdb, plot_all_records
 

--- a/wfdb/io/__init__.py
+++ b/wfdb/io/__init__.py
@@ -2,6 +2,6 @@ from .record import (Record, MultiRecord, rdheader, rdrecord, rdsamp, wrsamp,
                      dl_database, edf2mit, sampfreq, signame, SIGNAL_CLASSES)
 from ._signal import est_res, wr_dat_file
 from .annotation import (Annotation, rdann, wrann, show_ann_labels,
-                         show_ann_classes)
+                         show_ann_classes, ann2rr)
 from .download import get_dbs, get_record_list, dl_files, set_db_index_url
 from .tff import rdtff

--- a/wfdb/io/annotation.py
+++ b/wfdb/io/annotation.py
@@ -2268,7 +2268,7 @@ def ann2rr(record_name, extension, pn_dir=None, start_time=None,
     elif format == 'h':
         out_interval = time_interval / (60*60)
     else:
-        out_interval = (time_interval * ann.fs).astype(np.int)
+        out_interval = np.around(time_interval * ann.fs).astype(np.int)
 
     print(*out_interval, sep='\n')
 


### PR DESCRIPTION
Adds the `ann2rr` function from the [original WFDB software package](https://www.physionet.org/physiotools/wag/ann2rr-1.htm). This version sets the `-A` option as the default in place of `-c`. Both the `-f` and `-t` options are conserved which specify the desired start and stop time. The `-h` option can be found using `help(wfdb.ann2rr)`. The `-i` option is conserved except for the `t` parameter and specified number of decimal places. All the other options were not conserved since they can be determined using the current framework.