### PR TITLE
Converts relative imports to absolute

### DIFF
--- a/wfdb/__init__.py
+++ b/wfdb/__init__.py
@@ -1,8 +1,8 @@
-from .io.record import (Record, MultiRecord, rdheader, rdrecord, rdsamp,
-                        wrsamp, dl_database, edf2mit, sampfreq, signame)
-from .io.annotation import (Annotation, rdann, wrann, show_ann_labels,
-                            show_ann_classes, ann2rr)
-from .io.download import get_dbs, get_record_list, dl_files, set_db_index_url
-from .plot.plot import plot_items, plot_wfdb, plot_all_records
+from wfdb.io.record import (Record, MultiRecord, rdheader, rdrecord, rdsamp,
+                            wrsamp, dl_database, edf2mit, sampfreq, signame)
+from wfdb.io.annotation import (Annotation, rdann, wrann, show_ann_labels,
+                                show_ann_classes, ann2rr)
+from wfdb.io.download import get_dbs, get_record_list, dl_files, set_db_index_url
+from wfdb.plot.plot import plot_items, plot_wfdb, plot_all_records
 
-from .version import __version__
+from wfdb.version import __version__

--- a/wfdb/io/__init__.py
+++ b/wfdb/io/__init__.py
@@ -1,7 +1,7 @@
-from .record import (Record, MultiRecord, rdheader, rdrecord, rdsamp, wrsamp,
-                     dl_database, edf2mit, sampfreq, signame, SIGNAL_CLASSES)
-from ._signal import est_res, wr_dat_file
-from .annotation import (Annotation, rdann, wrann, show_ann_labels,
-                         show_ann_classes, ann2rr)
-from .download import get_dbs, get_record_list, dl_files, set_db_index_url
-from .tff import rdtff
+from wfdb.io.record import (Record, MultiRecord, rdheader, rdrecord, rdsamp, wrsamp,
+                            dl_database, edf2mit, sampfreq, signame, SIGNAL_CLASSES)
+from wfdb.io._signal import est_res, wr_dat_file
+from wfdb.io.annotation import (Annotation, rdann, wrann, show_ann_labels,
+                                show_ann_classes, ann2rr)
+from wfdb.io.download import get_dbs, get_record_list, dl_files, set_db_index_url
+from wfdb.io.tff import rdtff

--- a/wfdb/io/_header.py
+++ b/wfdb/io/_header.py
@@ -6,8 +6,8 @@ import pdb
 import numpy as np
 import pandas as pd
 
-from . import download
-from . import _signal
+from wfdb.io import download
+from wfdb.io import _signal
 
 
 """

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -3,7 +3,7 @@ import os
 
 import numpy as np
 
-from . import download
+from wfdb.io import download
 import pdb
 
 

--- a/wfdb/io/annotation.py
+++ b/wfdb/io/annotation.py
@@ -6,9 +6,9 @@ import re
 import posixpath
 import pdb
 
-from . import download
-from . import _header
-from . import record
+from wfdb.io import download
+from wfdb.io import _header
+from wfdb.io import record
 
 
 class Annotation(object):

--- a/wfdb/io/download.py
+++ b/wfdb/io/download.py
@@ -7,7 +7,7 @@ import requests
 import pdb
 import json
 
-from . import record
+from wfdb.io import record
 
 
 # The Physionet index url

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -12,9 +12,9 @@ import math
 import functools
 import pdb
 
-from . import _header
-from . import _signal
-from . import download
+from wfdb.io import _header
+from wfdb.io import _signal
+from wfdb.io import download
 
 
 # -------------- WFDB Signal Calibration and Classification ---------- #

--- a/wfdb/plot/__init__.py
+++ b/wfdb/plot/__init__.py
@@ -1,4 +1,4 @@
 """
 The plot subpackage contains tools for plotting signals and annotations.
 """
-from .plot import plot_items, plot_wfdb, plot_all_records
+from wfdb.plot.plot import plot_items, plot_wfdb, plot_all_records

--- a/wfdb/plot/plot.py
+++ b/wfdb/plot/plot.py
@@ -3,10 +3,10 @@ import numpy as np
 import os
 import pdb
 
-from ..io.record import Record, rdrecord
-from ..io._header import float_types
-from ..io._signal import downround, upround
-from ..io.annotation import Annotation
+from wfdb.io.record import Record, rdrecord
+from wfdb.io._header import float_types
+from wfdb.io._signal import downround, upround
+from wfdb.io.annotation import Annotation
 
 
 def plot_items(signal=None, ann_samp=None, ann_sym=None, fs=None,

--- a/wfdb/processing/__init__.py
+++ b/wfdb/processing/__init__.py
@@ -1,6 +1,6 @@
-from .basic import (resample_ann, resample_sig, resample_singlechan,
-                    resample_multichan, normalize_bound, get_filter_gain)
-from .evaluate import Comparitor, compare_annotations, benchmark_mitdb
-from .hr import compute_hr, calc_rr, calc_mean_hr
-from .peaks import find_peaks, find_local_peaks, correct_peaks
-from .qrs import XQRS, xqrs_detect, gqrs_detect
+from wfdb.processing.basic import (resample_ann, resample_sig, resample_singlechan,
+                                   resample_multichan, normalize_bound, get_filter_gain)
+from wfdb.processing.evaluate import Comparitor, compare_annotations, benchmark_mitdb
+from wfdb.processing.hr import compute_hr, calc_rr, calc_mean_hr
+from wfdb.processing.peaks import find_peaks, find_local_peaks, correct_peaks
+from wfdb.processing.qrs import XQRS, xqrs_detect, gqrs_detect

--- a/wfdb/processing/basic.py
+++ b/wfdb/processing/basic.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy import signal
 import pdb
 
-from ..io.annotation import Annotation
+from wfdb.io.annotation import Annotation
 
 
 def resample_ann(resampled_t, ann_sample):

--- a/wfdb/processing/evaluate.py
+++ b/wfdb/processing/evaluate.py
@@ -4,9 +4,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import requests
 
-from ..io.annotation import rdann
-from ..io.download import get_record_list
-from ..io.record import rdsamp
+from wfdb.io.annotation import rdann
+from wfdb.io.download import get_record_list
+from wfdb.io.record import rdsamp
 
 
 class Comparitor(object):

--- a/wfdb/processing/peaks.py
+++ b/wfdb/processing/peaks.py
@@ -1,7 +1,7 @@
 import copy
 import numpy as np
 
-from .basic import smooth
+from wfdb.processing.basic import smooth
 
 
 def find_peaks(sig):

--- a/wfdb/processing/qrs.py
+++ b/wfdb/processing/qrs.py
@@ -5,9 +5,9 @@ import numpy as np
 from scipy import signal
 from sklearn.preprocessing import normalize
 
-from .basic import get_filter_gain
-from .peaks import find_local_peaks
-from ..io.record import Record
+from wfdb.processing.basic import get_filter_gain
+from wfdb.processing.peaks import find_local_peaks
+from wfdb.io.record import Record
 
 
 class XQRS(object):


### PR DESCRIPTION
Converts all relative imports to absolute as per PEP8 guidelines. According to [documentation](https://www.python.org/dev/peps/pep-0008/#imports)... "Absolute imports are recommended, as they are usually more readable and tend to be better behaved (or at least give better error messages) if the import system is incorrectly configured (such as when a directory inside a package ends up on `sys.path`)". I actually encountered the previous error on #236 and had a tough time tracking down the error which prompted me to make this switch.