### PR TITLE
Fixes return_res error #230

### DIFF
--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -947,10 +947,6 @@ def _rd_segment(file_name, dir_name, pn_dir, fmt, n_sig, sig_len, byte_offset,
     if ignore_skew:
         skew = [0]*n_sig
 
-    # Change format if requested
-    if return_res != 64:
-        fmt = len(fmt) * [str(return_res)]
-
     # Get the set of dat files, and the
     # channels that belong to each file.
     file_name, datchannel = describe_list_indices(file_name)


### PR DESCRIPTION
Fixes error when using the `return_res` parameter which can sometimes modify the format in which the data from file is read. This oftentimes creates illogical arrays which can't be recovered into the proper values or even the proper shape. Fortunately, the removal of this does not significantly affect the runtime of the function even for large arrays. Fixes #230.