### PR TITLE
Produces EDF file from WFDB format

### DIFF
--- a/wfdb/__init__.py
+++ b/wfdb/__init__.py
@@ -1,5 +1,5 @@
 from wfdb.io.record import (Record, MultiRecord, rdheader, rdrecord, rdsamp,
-                            wrsamp, dl_database, edf2mit, wav2mit, wfdb2mat, sampfreq, signame)
+                            wrsamp, dl_database, edf2mit, mit2edf, wav2mit, wfdb2mat, sampfreq, signame)
 from wfdb.io.annotation import (Annotation, rdann, wrann, show_ann_labels,
                                 show_ann_classes, ann2rr)
 from wfdb.io.download import get_dbs, get_record_list, dl_files, set_db_index_url

--- a/wfdb/io/__init__.py
+++ b/wfdb/io/__init__.py
@@ -1,5 +1,5 @@
 from wfdb.io.record import (Record, MultiRecord, rdheader, rdrecord, rdsamp, wrsamp,
-                            dl_database, edf2mit, wav2mit, wfdb2mat, sampfreq, signame, SIGNAL_CLASSES)
+                            dl_database, edf2mit, mit2edf, wav2mit, wfdb2mat, sampfreq, signame, SIGNAL_CLASSES)
 from wfdb.io._signal import est_res, wr_dat_file
 from wfdb.io.annotation import (Annotation, rdann, wrann, show_ann_labels,
                                 show_ann_classes, ann2rr)

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -432,7 +432,7 @@ class SignalMixin(object):
                 for ch in range(self.n_sig):
                     # NAN locations for the channel
                     ch_nanlocs = np.isnan(self.e_p_signal[ch])
-                    ch_d_signal = self.e_p_signal.copy()
+                    ch_d_signal = self.e_p_signal[ch].copy()
                     np.multiply(ch_d_signal, self.adc_gain[ch], ch_d_signal)
                     np.add(ch_d_signal, self.baseline[ch], ch_d_signal)
                     ch_d_signal = ch_d_signal.astype(intdtype, copy=False)
@@ -704,9 +704,14 @@ class SignalMixin(object):
                 if current_dtype != return_dtype:
                     self.p_signal = self.p_signal.astype(return_dtype, copy=False)
             else:
-                for ch in range(self.n_sig):
-                    if self.e_p_signal[ch].dtype != return_dtype:
-                        self.e_p_signal[ch] = self.e_p_signal[ch].astype(return_dtype, copy=False)
+                if self.e_p_signal is not None:
+                    for ch in range(self.n_sig):
+                        if self.e_p_signal[ch].dtype != return_dtype:
+                            self.e_p_signal[ch] = self.e_p_signal[ch].astype(return_dtype, copy=False)
+                else:
+                    for ch in range(self.n_sig):
+                        if self.p_signal[ch].dtype != return_dtype:
+                            self.p_signal[ch] = self.p_signal[ch].astype(return_dtype, copy=False)
         else:
             return_dtype = 'int'+str(return_res)
             if smooth_frames is True:

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -1353,6 +1353,22 @@ def edf2mit(record_name, pn_dir=None, delete_file=True, record_only=False):
     """
     Convert EDF formatted files to MIT format.
 
+    Many EDF files contain signals at widely varying sampling frequencies.
+    `edf2mit` handles these properly, but the default behavior of most WFDB
+    applications is to read such data in low-resolution mode (in which all
+    signals are resampled at the lowest sampling frequency used for any signal
+    in the record). This is almost certainly not what you want if, for
+    example, the record contains EEG signals sampled at 200 Hz and body
+    temperature sampled at 1 Hz; by default, applications such as `rdsamp`
+    will resample the EEGs (and any other signals in the record) at 1 Hz. To
+    avoid this behavior, you can set `smooth_frames` to False (high resolution)
+    provided by `rdrecord` and a few other WFDB applications.
+
+    Note that applications built using version 3.1.0 and later versions of
+    the WFDB-Python library can read EDF files directly, so that the conversion
+    performed by `edf2mit` is no longer necessary. However, one can still use
+    this function to produce WFDB-compatible files from EDF files if desired.
+
     Parameters
     ----------
     record_name : str
@@ -1496,6 +1512,383 @@ def edf2mit(record_name, pn_dir=None, delete_file=True, record_only=False):
     else:
         # TODO: Generate the .dat and .hea files
         pass
+
+
+def mit2edf(record_name, pn_dir=None, sampfrom=0, sampto=None, channels=None,
+             output_filename='', edf_plus=False):
+    """
+    These programs convert EDF (European Data Format) files into
+    WFDB-compatible files (as used in PhysioNet) and vice versa. European
+    Data Format (EDF) was originally designed for storage of polysomnograms.
+
+    Note that WFDB format does not include a standard way to specify the
+    transducer type or the prefiltering specification; these parameters are
+    not preserved by these conversion programs. Also note that use of the
+    standard signal and unit names specified for EDF is permitted but not
+    enforced by `mit2edf`.
+
+    Parameters
+    ----------
+    record_name : str
+        The name of the input WFDB record to be read. Can also work with both
+        EDF and WAV files.
+    pn_dir : str, optional
+        Option used to stream data from Physionet. The Physionet
+        database directory from which to find the required record files.
+        eg. For record '100' in 'http://physionet.org/content/mitdb'
+        pn_dir='mitdb'.
+    sampfrom : int, optional
+        The starting sample number to read for all channels.
+    sampto : int, 'end', optional
+        The sample number at which to stop reading for all channels.
+        Reads the entire duration by default.
+    channels : list, optional
+        List of integer indices specifying the channels to be read.
+        Reads all channels by default.
+    output_filename : str, optional
+        The desired name of the output file. If this value set to the
+        default value of '', then the output filename will be 'REC.edf'.
+    edf_plus : bool, optional
+        Whether to write the output file in EDF (False) or EDF+ (True) format.
+
+    Returns
+    -------
+    N/A
+
+    Notes
+    -----
+    The entire file is composed of (seen here: https://www.edfplus.info/specs/edf.html):
+
+    HEADER RECORD (we suggest to also adopt the 12 simple additional EDF+ specs)
+    8 ascii : version of this data format (0)
+    80 ascii : local patient identification (mind item 3 of the additional EDF+ specs)
+    80 ascii : local recording identification (mind item 4 of the additional EDF+ specs)
+    8 ascii : startdate of recording (dd.mm.yy) (mind item 2 of the additional EDF+ specs)
+    8 ascii : starttime of recording (hh.mm.ss)
+    8 ascii : number of bytes in header record
+    44 ascii : reserved
+    8 ascii : number of data records (-1 if unknown, obey item 10 of the additional EDF+ specs)
+    8 ascii : duration of a data record, in seconds
+    4 ascii : number of signals (ns) in data record
+    ns * 16 ascii : ns * label (e.g. EEG Fpz-Cz or Body temp) (mind item 9 of the additional EDF+ specs)
+    ns * 80 ascii : ns * transducer type (e.g. AgAgCl electrode)
+    ns * 8 ascii : ns * physical dimension (e.g. uV or degreeC)
+    ns * 8 ascii : ns * physical minimum (e.g. -500 or 34)
+    ns * 8 ascii : ns * physical maximum (e.g. 500 or 40)
+    ns * 8 ascii : ns * digital minimum (e.g. -2048)
+    ns * 8 ascii : ns * digital maximum (e.g. 2047)
+    ns * 80 ascii : ns * prefiltering (e.g. HP:0.1Hz LP:75Hz)
+    ns * 8 ascii : ns * nr of samples in each data record
+    ns * 32 ascii : ns * reserved
+
+    DATA RECORD
+    nr of samples[1] * integer : first signal in the data record
+    nr of samples[2] * integer : second signal
+    ..
+    ..
+    nr of samples[ns] * integer : last signal
+
+    Bytes   0 - 127: descriptive text
+    Bytes 128 - 131: master tag (data type = matrix)
+    Bytes 132 - 135: master tag (data size)
+    Bytes 136 - 151: array flags (4 byte tag with data type, 4 byte
+                     tag with subelement size, 8 bytes of content)
+    Bytes 152 - 167: array dimension (4 byte tag with data type, 4
+                     byte tag with subelement size, 8 bytes of content)
+    Bytes 168 - 183: array name (4 byte tag with data type, 4 byte
+                     tag with subelement size, 8 bytes of content)
+    Bytes 184 - ...: array content (4 byte tag with data type, 4 byte
+                     tag with subelement size, ... bytes of content)
+
+    Examples
+    --------
+    >>> wfdb.mit2edf('100', pn_dir='pwave')
+
+    The output file name is '100.edf'
+
+    """
+    record = rdrecord(record_name, pn_dir=pn_dir, sampfrom=sampfrom,
+                      sampto=sampto, smooth_frames=False)
+    record_name_out = record_name.split(os.sep)[-1].replace('-','_')
+
+    # Maximum data block length, in bytes
+    edf_max_block = 61440
+
+    # Convert to the expected month name formatting
+    month_names = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG',
+                   'SEP', 'OCT', 'NOV', 'DEC']
+
+    # Calculate block duration. (In the EDF spec, blocks are called "records"
+    # or "data records", but this would be confusing here since "record"
+    # refers to the entire recording -- so here we say "blocks".)
+    samples_per_frame = sum(record.samps_per_frame)
+
+    # i.e., The number of frames per minute, divided by 60
+    frames_per_minute = record.fs * 60 + 0.5
+    frames_per_second = frames_per_minute / 60
+
+    # Ten seconds
+    frames_per_block = 10 * frames_per_second + 0.5
+
+    # EDF specifies 2 bytes per sample
+    bytes_per_block = int(2 * samples_per_frame * frames_per_block)
+
+    # Blocks would be too long -- reduce their length by a factor of 10
+    while (bytes_per_block > edf_max_block):
+        frames_per_block /= 10
+        bytes_per_block = samples_per_frame * 2 * frames_per_block
+
+    seconds_per_block = int(frames_per_block / frames_per_second)
+
+    if (frames_per_block < 1) and (bytes_per_block < edf_max_block/60):
+        # The number of frames/minute
+        frames_per_block = frames_per_minute
+        bytes_per_block = 2 * samples_per_frame * frames_per_block
+        seconds_per_block = 60
+
+    if (bytes_per_block > edf_max_block):
+        print(("Can't convert record %s to EDF: EDF blocks can't be larger "
+               "than {} bytes, but each input frame requires {} bytes.  Use "
+               "'channels' to select a subset of the input signals or trim "
+               "using 'sampfrom' and 'sampto'.").format(edf_max_block,
+                                                        samples_per_frame * 2))
+
+    # Calculate the number of blocks to be written. The calculation rounds
+    # up so that we don't lose any frames, even if the number of frames is not
+    # an exact multiple of frames_per_block
+    total_frames = record.sig_len
+    num_blocks = int(total_frames / int(frames_per_block)) + 1
+
+    digital_min = []
+    digital_max = []
+    physical_min = []
+    physical_max = []
+    # Calculate the physical and digital extrema
+    for i in range(record.n_sig):
+        # Invalid ADC resolution in input .hea file
+        if (record.adc_res[i] < 1):
+            # Guess the ADC resolution based on format
+            if record.fmt[i] == '24':
+                temp_adc_res = 24
+            elif record.fmt[i] == '32':
+                temp_adc_res = 32
+            elif record.fmt[i] == '80':
+                temp_adc_res = 8
+            elif record.fmt[i] == '212':
+                temp_adc_res = 12
+            elif (record.fmt[i] == '310') or (record.fmt[i] == '311'):
+                temp_adc_res = 10
+            else:
+                temp_adc_res = 16
+        else:
+            temp_adc_res = record.adc_res[i]
+        # Determine the physical and digital extrema
+        digital_max.append(int(record.adc_zero[i] + (1 << (temp_adc_res - 1)) - 1))
+        digital_min.append(int(record.adc_zero[i] - (1 << (temp_adc_res - 1))))
+        physical_max.append((digital_max[i] - record.baseline[i]) / record.adc_gain[i])
+        physical_min.append((digital_min[i] - record.baseline[i]) / record.adc_gain[i])
+
+    # The maximum record name length to write is 80 bytes
+    if len(record_name_out) > 80:
+        record_name_write = record_name_out[:79] + '\0'
+    else:
+        record_name_write = record_name_out
+
+    # The maximum seconds per block length to write is 8 bytes
+    if len(str(seconds_per_block)) > 8:
+        seconds_per_block_write = seconds_per_block[:7] + '\0'
+    else:
+        seconds_per_block_write = seconds_per_block
+
+    # The maximum signal name length to write is 16 bytes
+    sig_name_write = len(record.sig_name) * []
+    for s in record.sig_name:
+        if len(s) > 16:
+            sig_name_write.append(s[:15] + '\0')
+        else:
+            sig_name_write.append(s)
+
+    # The maximum units length to write is 8 bytes
+    units_write = len(record.units) * []
+    for s in record.units:
+        if len(s) > 8:
+            units_write.append(s[:7] + '\0')
+        else:
+            units_write.append(s)
+
+    # Configure the output datetime
+    if hasattr('record', 'base_datetime'):
+        start_second = int(record.base_datetime.second)
+        start_minute = int(record.base_datetime.minute)
+        start_hour = int(record.base_datetime.hour)
+        start_day = int(record.base_datetime.day)
+        start_month = int(record.base_datetime.month)
+        start_year = int(record.base_datetime.year)
+    else:
+        # Set date to start of EDF epoch
+        start_second = 0
+        start_minute = 0
+        start_hour = 0
+        start_day = 1
+        start_month = 1
+        start_year = 1985
+
+    # Determine the number of bytes in the header
+    header_bytes = 256 * (record.n_sig + 1)
+
+    # Determine the number of samples per data record
+    samps_per_record = []
+    for spf in record.samps_per_frame:
+        samps_per_record.append(int(frames_per_block) * spf)
+
+    # Determine the output data
+    # NOTE: The output data will be close (+-1) but not equal due to the
+    #       inappropriate rounding done by record.adc()
+    #       For example...
+    #           Mismatched elements: 862881 / 24168000 (3.57%)
+    #           Max absolute difference: 1
+    #           Max relative difference: 0.0212766
+    #            x: array([ 53, -28,  14, ..., 884, 898, 898], dtype=int16)
+    #            y: array([ 53, -28,  14, ..., 884, 898, 898], dtype=int16)
+    if record.e_p_signal is not None:
+        temp_data = record.adc(expanded=True)
+    else:
+        temp_data = record.adc()
+        temp_data = [v for v in np.transpose(temp_data)]
+
+    out_data = []
+    for i in range(record.sig_len):
+        for j,sig in enumerate(temp_data):
+            ind_start = i * samps_per_record[j]
+            ind_stop = (i+1) * samps_per_record[j]
+            out_data.extend(sig[ind_start:ind_stop].tolist())
+    out_data = np.array(out_data, dtype=np.int16)
+
+    # Start writing the file
+    if output_filename == '':
+        output_filename = record_name_out + '.edf'
+
+    with open(output_filename, 'wb') as f:
+
+        print('Converting record {} to {} ({} mode)'.format(record_name, output_filename, 'EDF+' if edf_plus else 'EDF'))
+
+        # Version of this data format (8 bytes)
+        f.write(struct.pack('<8s', b'0').replace(b'\x00',b'\x20'))
+
+        # Local patient identification (80 bytes)
+        f.write(struct.pack('<80s', '{}'.format(record_name_write).encode('ascii')).replace(b'\x00',b'\x20'))
+
+        # Local recording identification (80 bytes)
+        # Bob Kemp recommends using this field to encode the start date
+        # including an abbreviated month name in English and a full (4-digit)
+        # year, as is done here if this information is available in the input
+        # record. EDF+ requires this.
+        if hasattr('record', 'base_datetime'):
+            f.write(struct.pack('<80s', 'Startdate {}-{}-{}'.format(start_day, month_names[start_month-1], start_year).encode('ascii')).replace(b'\x00',b'\x20'))
+        else:
+            f.write(struct.pack('<80s', b'Startdate not recorded').replace(b'\x00',b'\x20'))
+        if edf_plus:
+            print('WARNING: EDF+ requires start date (not specified)')
+
+        # Start date of recording (dd.mm.yy) (8 bytes)
+        f.write(struct.pack('<8s', '{:02d}.{:02d}.{:02d}'.format(start_day, start_month, start_year%100).encode('ascii')).replace(b'\x00',b'\x20'))
+
+        # Start time of recording (hh.mm.ss) (8 bytes)
+        f.write(struct.pack('<8s', '{:02d}.{:02d}.{:02d}'.format(start_hour, start_minute, start_second).encode('ascii')).replace(b'\x00',b'\x20'))
+
+        # Number of bytes in header (8 bytes)
+        f.write(struct.pack('<8s', '{:d}'.format(header_bytes).encode('ascii')).replace(b'\x00',b'\x20'))
+
+        # Reserved (44 bytes)
+        if edf_plus:
+            f.write(struct.pack('<44s', b'EDF+C').replace(b'\x00',b'\x20'))
+        else:
+            f.write(struct.pack('<44s', b'').replace(b'\x00',b'\x20'))
+
+        # Number of blocks (-1 if unknown) (8 bytes)
+        f.write(struct.pack('<8s', '{:d}'.format(num_blocks).encode('ascii')).replace(b'\x00',b'\x20'))
+
+        # Duration of a block, in seconds (8 bytes)
+        f.write(struct.pack('<8s', '{:g}'.format(seconds_per_block_write).encode('ascii')).replace(b'\x00',b'\x20'))
+
+        # Number of signals (4 bytes)
+        f.write(struct.pack('<4s', '{:d}'.format(record.n_sig).encode('ascii')).replace(b'\x00',b'\x20'))
+
+        # Label (e.g., EEG FpzCz or Body temp) (16 bytes each)
+        for i in sig_name_write:
+            f.write(struct.pack('<16s', '{}'.format(i).encode('ascii')).replace(b'\x00',b'\x20'))
+
+        # Transducer type (e.g., AgAgCl electrode) (80 bytes each)
+        for _ in range(record.n_sig):
+            f.write(struct.pack('<80s', b'transducer type not recorded').replace(b'\x00',b'\x20'))
+
+        # Physical dimension (e.g., uV or degreeC) (8 bytes each)
+        for i in units_write:
+            f.write(struct.pack('<8s', '{}'.format(i).encode('ascii')).replace(b'\x00',b'\x20'))
+
+        # Physical minimum (e.g., -500 or 34) (8 bytes each)
+        for pmin in physical_min:
+            f.write(struct.pack('<8s', '{:g}'.format(pmin).encode('ascii')).replace(b'\x00',b'\x20'))
+
+        # Physical maximum (e.g., 500 or 40) (8 bytes each)
+        for pmax in physical_max:
+            f.write(struct.pack('<8s', '{:g}'.format(pmax).encode('ascii')).replace(b'\x00',b'\x20'))
+
+        # Digital minimum (e.g., -2048) (8 bytes each)
+        for dmin in digital_min:
+            f.write(struct.pack('<8s', '{:d}'.format(dmin).encode('ascii')).replace(b'\x00',b'\x20'))
+
+        # Digital maximum (e.g., 2047) (8 bytes each)
+        for dmax in digital_max:
+            f.write(struct.pack('<8s', '{:d}'.format(dmax).encode('ascii')).replace(b'\x00',b'\x20'))
+
+        # Prefiltering (e.g., HP:0.1Hz LP:75Hz) (80 bytes each)
+        for _ in range(record.n_sig):
+            f.write(struct.pack('<80s', b'prefiltering not recorded').replace(b'\x00',b'\x20'))
+
+        # Number of samples per block (8 bytes each)
+        for spr in samps_per_record:
+            f.write(struct.pack('<8s', '{:d}'.format(spr).encode('ascii')).replace(b'\x00',b'\x20'))
+
+        # The last 32*nsig bytes in the header are unused
+        for _ in range(record.n_sig):
+            f.write(struct.pack('<32s', b'').replace(b'\x00',b'\x20'))
+
+        # Write the data blocks
+        out_data.tofile(f, format='%d')
+
+        # Add the buffer
+        correct_bytes = num_blocks * sum(samps_per_record)
+        current_bytes = len(out_data)
+        num_to_write = correct_bytes - current_bytes
+        for i in range(num_to_write):
+            f.write(b'\x00\x80')
+
+    print('Header block size: {:d} bytes'.format((record.n_sig+1) * 256))
+    print('Data block size: {:g} seconds ({:d} frames or {:d} bytes)'.format(seconds_per_block, int(frames_per_block), int(bytes_per_block)))
+    print('Recording length: {:d} ({:d} data blocks, {:d} frames, {:d} bytes)'.format(sum([num_blocks, num_blocks*int(frames_per_block), num_blocks*bytes_per_block]), num_blocks, num_blocks*int(frames_per_block), num_blocks*bytes_per_block))
+    print('Total length of file to be written: {:d} bytes'.format(int((record.n_sig+1)*256 + num_blocks*bytes_per_block)))
+
+    if edf_plus:
+        print(("WARNING: EDF+ requires the subject's gender, birthdate, and name, as "
+               "well as additional information about the recording that is not usually "
+               "available. This information is not saved in the output file even if "
+               "available. EDF+ also requires the use of standard names for signals and "
+               "for physical units;  these requirements are not enforced by this program. "
+               "To make the output file fully EDF+ compliant, its header must be edited "
+               "manually."))
+
+        if 'EDF-Annotations' not in record.sig_name:
+            print('WARNING: The output file does not include EDF annotations, which are required for EDF+.')
+
+    # Check that all characters in the header are valid (printable ASCII
+    # between 32 and 126 inclusive). Note that this test does not prevent
+    # generation of files containing invalid characters; it merely warns
+    # the user if this has happened.
+    header_test = open(output_filename,'rb').read((record.n_sig + 1) * 256)
+    for i,val in enumerate(header_test):
+        if (val < 32) or (val > 126):
+            print('WARNING: output contains an invalid character, {}, at byte {}'.format(val, i))
 
 
 def wav2mit(record_name, pn_dir=None, delete_file=True, record_only=False):


### PR DESCRIPTION
Introduces the conversion of WFDB files to EDF format. All data was written to the EDF file using `struck.pack()` so no outside packages were introduced. This implementation conserves the `-h` option which can now be used with `help(wfdb.wfdb2edf)`. Further, the `-v` option was conserved and is no longer an option so all content will be printed to screen to help the user see what is going on and the specifications of their EDF file. The `-o` option, which is used to specify their desired EDF file name, is also conserved. The default behavior is that an input record named "100" would now produce an EDF file named "100.edf".