### PR TITLE
Fixes erroneous URL #247

### DIFF
--- a/wfdb/io/download.py
+++ b/wfdb/io/download.py
@@ -513,7 +513,7 @@ def dl_files(db, dl_dir, files, keep_subdirs=True, overwrite=False):
     """
     # Full url PhysioNet database
     db_dir = posixpath.join(db, record.get_version(db))
-    db_url = posixpath.join(PN_CONTENT_URL, db_dir) + os.sep
+    db_url = posixpath.join(PN_CONTENT_URL, db_dir) + '/'
 
     # Check if the database is valid
     response = requests.get(db_url)

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -3381,7 +3381,7 @@ def dl_database(db_dir, dl_dir, records='all', annotators='all',
         db_dir = posixpath.join(dir_list[0], get_version(dir_list[0]), *dir_list[1:])
     else:
         db_dir = posixpath.join(db_dir, get_version(db_dir))
-    db_url = posixpath.join(download.PN_CONTENT_URL, db_dir) + os.sep
+    db_url = posixpath.join(download.PN_CONTENT_URL, db_dir) + '/'
     # Check if the database is valid
     r = requests.get(db_url)
     r.raise_for_status()


### PR DESCRIPTION
Fixes URL generation for Windows machines by removing the `os.sep` operation. Fixes #247.