### PR TITLE
Fixes NameError in annotation except statement #253

### DIFF
--- a/wfdb/io/annotation.py
+++ b/wfdb/io/annotation.py
@@ -1717,7 +1717,7 @@ def check_read_inputs(sampfrom, sampto, return_label_elements):
         return_label_elements = [return_label_elements]
 
     if set.union(set(ann_label_fields), set(return_label_elements))!=set(ann_label_fields):
-        raise ValueError('return_label_elements must be a list containing one or more of the following elements:',label_types)
+        raise ValueError('return_label_elements must be a list containing one or more of the following elements:',ann_label_fields)
 
     return return_label_elements
 


### PR DESCRIPTION
Fixes the `NameError` that occurs when incorrect `return_label_elements` are provided while trying to read an annotation file. Fixes #253.