### PR TITLE
Prune requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,5 @@ pytz==2020.1
 requests==2.23.0
 scikit-learn==0.22.2.post1
 scipy==1.4.1
-six==1.15.0
 threadpoolctl==2.1.0
 urllib3==1.25.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,5 @@ requests==2.23.0
 scikit-learn==0.22.2.post1
 scipy==1.4.1
 six==1.15.0
-sklearn==0.0
 threadpoolctl==2.1.0
 urllib3==1.25.9

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ setup(
         'kiwisolver>=1.1.0',
         'matplotlib>=2.0.0',
         'mne>=0.18.0',
-        'nose>=1.3.7',
         'numpy>=1.10.1',
         'pandas>=0.17.0',
         'pyparsing>=2.0.4',
@@ -82,10 +81,9 @@ setup(
     # dependencies). You can install these using the following syntax,
     # for example:
     # $ pip install -e .[dev,test]
-    # extras_require={
-    #     'dev': ['check-manifest'],
-    #     'test': ['coverage'],
-    # },
+    extras_require={
+        'test': ['nose>=1.3.7']
+    },
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ setup(
         'requests>=2.8.1',
         'scikit-learn>=0.18',
         'scipy>=0.17.0',
-        'six>=0.9.0',
         'threadpoolctl>=1.0.0',
         'urllib3>=1.22'
     ],

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,6 @@ setup(
         'scikit-learn>=0.18',
         'scipy>=0.17.0',
         'six>=0.9.0',
-        'sklearn>=0.0',
         'threadpoolctl>=1.0.0',
         'urllib3>=1.22'
     ],


### PR DESCRIPTION
I just did `pip install wfdb` and noticed that there are some dependencies that can probably be removed. The package `sklearn` is not a real package (you want `scikit-learn`) so it should be removed. I've also moved `nose` to `extras_require` because it is not required for normal usage (I've kept it in `requirements.txt` though). Finally, I think `six` is never used in the project so I've removed it. Not sure if there are more unused dependencies, but these are probably the most important fixes. Let me know what you think.