### PR TITLE
Fixes download fail on Windows #262

### DIFF
--- a/wfdb/io/download.py
+++ b/wfdb/io/download.py
@@ -278,7 +278,7 @@ def get_record_list(db_dir, records='all'):
 
     """
     # Full url PhysioNet database
-    if os.sep not in db_dir:
+    if '/' not in db_dir:
         db_url = posixpath.join(config.db_index_url, db_dir, record.get_version(db_dir))
     else:
         db_url = posixpath.join(config.db_index_url, db_dir)


### PR DESCRIPTION
Replaces `os.sep` with `/` to indicate a URL and prevent issues on Windows machines since `os.sep` on Windows is `\`. Fixes #262.