### PR TITLE
Minor fix in wfdb-python/wfdb/processing/peaks.py

### DIFF
--- a/wfdb/processing/peaks.py
+++ b/wfdb/processing/peaks.py
@@ -229,7 +229,7 @@ def shift_peaks(sig, peak_inds, search_radius, peak_up):
         ind = peak_inds[i]
         if ind >= search_radius:
             break
-        shift_inds[i] -= search_radius - ind
+        shift_inds[i] += search_radius - ind
 
     shifted_peak_inds = peak_inds + shift_inds - search_radius
 


### PR DESCRIPTION
In the current code, it does not work well when `ind < search_radius`.