### PR TITLE
Relaxes requirements for pytz

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         'pandas>=0.17.0',
         'pyparsing>=2.0.4',
         'python-dateutil>=2.4.2',
-        'pytz>=2018.3',
+        'pytz>=2017.2',
         'requests>=2.8.1',
         'scikit-learn>=0.18',
         'scipy>=0.17.0',


### PR DESCRIPTION
This change relaxes the requirements for the `pytz` package from `>=2018.3` to `>= 2017.2` since it is only required by `pandas` which only requires `pytz>=2017.2`.