### PR TITLE
Fixes NoneType error in wfdb.io.wrann when using label_store instead of symbol #260

### DIFF
--- a/wfdb/io/annotation.py
+++ b/wfdb/io/annotation.py
@@ -280,6 +280,11 @@ class Annotation(object):
         if 'label_store' not in present_label_fields:
             self.convert_label_attribute(source_field=present_label_fields[0],
                                          target_field='label_store')
+            
+        # Calculate the symbol field if necessary
+        if 'symbol' not in present_label_fields:
+            self.convert_label_attribute(source_field=present_label_fields[0],
+                                         target_field='symbol')
 
         # Write the header file using the specified fields
         self.wr_ann_file(write_fs=write_fs, write_dir=write_dir)


### PR DESCRIPTION
`symbol` needs to be defined in `calc_core_bytes` so the annotations can be converted into bytes for writing.  I added this to define `symbol` when `label_store` is being used:

```
 # Calculate the symbol field if necessary
        if 'symbol' not in present_label_fields:
            self.convert_label_attribute(source_field=present_label_fields[0],
                                         target_field='symbol')
```