### PR TITLE
Adds wfdbdesc function

### DIFF
--- a/wfdb/__init__.py
+++ b/wfdb/__init__.py
@@ -1,6 +1,6 @@
 from wfdb.io.record import (Record, MultiRecord, rdheader, rdrecord, rdsamp,
                             wrsamp, dl_database, edf2mit, mit2edf, wav2mit, mit2wav,
-                            wfdb2mat, csv2mit, sampfreq, signame)
+                            wfdb2mat, csv2mit, sampfreq, signame, wfdbdesc)
 from wfdb.io.annotation import (Annotation, rdann, wrann, show_ann_labels,
                                 show_ann_classes, ann2rr, rr2ann)
 from wfdb.io.download import get_dbs, get_record_list, dl_files, set_db_index_url

--- a/wfdb/io/__init__.py
+++ b/wfdb/io/__init__.py
@@ -1,6 +1,6 @@
 from wfdb.io.record import (Record, MultiRecord, rdheader, rdrecord, rdsamp, wrsamp,
                             dl_database, edf2mit, mit2edf, wav2mit, mit2wav, wfdb2mat,
-                            csv2mit, sampfreq, signame, SIGNAL_CLASSES)
+                            csv2mit, sampfreq, signame, wfdbdesc, SIGNAL_CLASSES)
 from wfdb.io._signal import est_res, wr_dat_file
 from wfdb.io.annotation import (Annotation, rdann, wrann, show_ann_labels,
                                 show_ann_classes, ann2rr, rr2ann)


### PR DESCRIPTION
This change adds the `wfdbdesc` function from the [original WFDB package](https://www.physionet.org/physiotools/wag/wfdbde-1.htm). The only difference here is that I chose to limit the description of multi-segment headers to just the header itself instead of diving into each of the records it calls (I thought this might be a bit more consistent behavior). This can be added as a feature later though.