### PR TITLE
Adds wfdbtime function

### DIFF
--- a/wfdb/__init__.py
+++ b/wfdb/__init__.py
@@ -1,6 +1,6 @@
 from wfdb.io.record import (Record, MultiRecord, rdheader, rdrecord, rdsamp,
                             wrsamp, dl_database, edf2mit, mit2edf, wav2mit, mit2wav,
-                            wfdb2mat, csv2mit, sampfreq, signame, wfdbdesc)
+                            wfdb2mat, csv2mit, sampfreq, signame, wfdbdesc, wfdbtime)
 from wfdb.io.annotation import (Annotation, rdann, wrann, show_ann_labels,
                                 show_ann_classes, ann2rr, rr2ann)
 from wfdb.io.download import get_dbs, get_record_list, dl_files, set_db_index_url

--- a/wfdb/io/__init__.py
+++ b/wfdb/io/__init__.py
@@ -1,6 +1,6 @@
 from wfdb.io.record import (Record, MultiRecord, rdheader, rdrecord, rdsamp, wrsamp,
                             dl_database, edf2mit, mit2edf, wav2mit, mit2wav, wfdb2mat,
-                            csv2mit, sampfreq, signame, wfdbdesc, SIGNAL_CLASSES)
+                            csv2mit, sampfreq, signame, wfdbdesc, wfdbtime, SIGNAL_CLASSES)
 from wfdb.io._signal import est_res, wr_dat_file
 from wfdb.io.annotation import (Annotation, rdann, wrann, show_ann_labels,
                                 show_ann_classes, ann2rr, rr2ann)


### PR DESCRIPTION
This change adds the `wfdbtime` function from the [original WFDB package](https://www.physionet.org/physiotools/wag/wfdbti-1.htm). All of the original functionality should still be available, however the method used to input the arguments is different. For this implementation, users must provide their desired time argument as either a single string or list of multiple strings.

The input formats are also the same, which is an integer (in which case '1' will be interpreted as 1 second), a datetime format (hh:mm:ss.sss DD/MM/YYYY), or prefixed with the letter 's' if the time at a selected sample is desired (i.e. 's10' for sample time). For the datetime format, 0's do not have be filled for all values (i.e. '5::' will be interpreted as '05:00:00.000',  ':5:' will be '00:05:00.000', etc.). The string 'e' can be used to represent the end of the record.