### PR TITLE
Adds Amazon AWS S3 support #268

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ scikit-learn==0.22.2.post1
 scipy==1.4.1
 threadpoolctl==2.1.0
 urllib3==1.25.9
+s3fs==2021.4.0

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,8 @@ setup(
         'scikit-learn>=0.18',
         'scipy>=0.17.0',
         'threadpoolctl>=1.0.0',
-        'urllib3>=1.22'
+        'urllib3>=1.22',
+        's3fs>=2021.4.0'
     ],
 
     # List additional groups of dependencies here (e.g. development

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -2091,7 +2091,7 @@ def _infer_sig_len(file_name, fmt, n_sig, dir_name, pn_dir=None):
         file_size = os.path.getsize(os.path.join(dir_name, file_name))
     else:
         file_size = download._remote_file_size(file_name=file_name,
-                                               pn_dir=pn_dir)
+                                               remote_dir=pn_dir)
 
     sig_len = int(file_size / (BYTES_PER_SAMPLE[fmt] * n_sig))
 

--- a/wfdb/io/annotation.py
+++ b/wfdb/io/annotation.py
@@ -1620,7 +1620,7 @@ def rdann(record_name, extension, sampfrom=0, sampto=None, shift_samps=False,
     >>> ann = wfdb.rdann('sample-data/100', 'atr', sampto=300000)
 
     """
-    if (pn_dir is not None) and ('.' not in pn_dir):
+    if (pn_dir is not None) and ('.' not in pn_dir) and (not pn_dir.startswith('s3')):
         dir_list = pn_dir.split('/')
         pn_dir = posixpath.join(dir_list[0],
                                 record.get_version(dir_list[0]),
@@ -2255,7 +2255,7 @@ def ann2rr(record_name, extension, pn_dir=None, start_time=None,
     >>> 257
 
     """
-    if (pn_dir is not None) and ('.' not in pn_dir):
+    if (pn_dir is not None) and ('.' not in pn_dir) and (not pn_dir.startswith('s3')):
         dir_list = pn_dir.split('/')
         pn_dir = posixpath.join(dir_list[0], record.get_version(dir_list[0]),
                                 *dir_list[1:])


### PR DESCRIPTION
This change adds support for data stored in Amazon AWS S3 (buckets). For the moment, anywhere there is a `pn_dir` parameter in a function, the user can provide the S3 URI form which to find the desired input file. This should always begin with `'s3'` in order to work correctly. An example input would be: `'s3://my-aws-bucket/'`.

For example, I can read record `100` (both `.dat` and `.hea`) stored on `my-aws-bucket` like this:
```
>>> import wfdb
>>> rec = wfdb.rdrecord('100', pn_dir='s3://my-aws-bucket')
```

As mentioned in #73, I think it would be nice to transition away from WFDB's dependence on files and take an approach similar to this statement:
```
1. You have the wfdb-python library that only takes contents as input
2. You have helper functions (downloads from physionet and read the contents for you)
```
Where each helper function would be for a separate application (PhysioNet, AWS S3, Hadoop HDFS, etc.). This would probably be a significant change (I think `pn_dir` should be changed to `remote_dir` at least) so something to look forward to in `v4.0`??

Fixes #268.