### PR TITLE
Fixes request redirect bug

### DIFF
--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -1242,7 +1242,7 @@ def get_version(pn_dir):
 
     """
     db_dir = pn_dir.split('/')[0]
-    url = posixpath.join(download.PN_CONTENT_URL, db_dir)
+    url = posixpath.join(download.PN_CONTENT_URL, db_dir) + '/'
     response = requests.get(url)
     contents = [line.decode('utf-8').strip() for line in response.content.splitlines()]
     version_number = [v for v in contents if 'Version:' in v]


### PR DESCRIPTION
It seems like sometimes Github Actions runs into issues when using `requests.get()`, specifically the error:
```
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='physionet.org', port=443): Max retries
exceeded with url: /content/wfdb (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object
at 0x119995640>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not
known'))
```
I think this is, at least in part, due to the lack of the extra forward slash in the `wfdb.io.record.get_version` function. To confirm, I did some analysis into the request history:
```
>>> requests.get('https://physionet.org/content/wfdb/').history
[<Response [302]>]
>>> requests.get('https://physionet.org/content/wfdb').history
[<Response [301]>, <Response [302]>]
```
From this, we can see the actual redirect location from the headers which causes the strange behavior:
```
>>> requests.get('https://physionet.org/content/wfdb/', allow_redirects=False).headers['Location']
'/content/wfdb/10.6.2/'
>>> requests.get('https://physionet.org/content/wfdb', allow_redirects=False).headers['Location']
'/content/wfdb/'
```