### PR TITLE
Adds sigavg function

### DIFF
--- a/wfdb/__init__.py
+++ b/wfdb/__init__.py
@@ -1,6 +1,7 @@
 from wfdb.io.record import (Record, MultiRecord, rdheader, rdrecord, rdsamp,
-                            wrsamp, dl_database, edf2mit, mit2edf, wav2mit, mit2wav,
-                            wfdb2mat, csv2mit, sampfreq, signame, wfdbdesc, wfdbtime)
+                            wrsamp, dl_database, edf2mit, mit2edf, wav2mit,
+                            mit2wav, wfdb2mat, csv2mit, sampfreq, signame,
+                            wfdbdesc, wfdbtime, sigavg)
 from wfdb.io.annotation import (Annotation, rdann, wrann, show_ann_labels,
                                 show_ann_classes, ann2rr, rr2ann, csv2ann,
                                 rdedfann, mrgann)

--- a/wfdb/io/__init__.py
+++ b/wfdb/io/__init__.py
@@ -1,6 +1,7 @@
-from wfdb.io.record import (Record, MultiRecord, rdheader, rdrecord, rdsamp, wrsamp,
-                            dl_database, edf2mit, mit2edf, wav2mit, mit2wav, wfdb2mat,
-                            csv2mit, sampfreq, signame, wfdbdesc, wfdbtime, SIGNAL_CLASSES)
+from wfdb.io.record import (Record, MultiRecord, rdheader, rdrecord, rdsamp,
+                            wrsamp, dl_database, edf2mit, mit2edf, wav2mit,
+                            mit2wav, wfdb2mat, csv2mit, sampfreq, signame,
+                            wfdbdesc, wfdbtime, sigavg, SIGNAL_CLASSES)
 from wfdb.io._signal import est_res, wr_dat_file
 from wfdb.io.annotation import (Annotation, rdann, wrann, show_ann_labels,
                                 show_ann_classes, ann2rr, rr2ann, csv2ann,

--- a/wfdb/io/annotation.py
+++ b/wfdb/io/annotation.py
@@ -3133,6 +3133,14 @@ class AnnotationLabel(object):
     def __str__(self):
         return str(self.label_store)+', '+str(self.symbol)+', '+str(self.short_description)+', '+str(self.description)
 
+is_qrs = [
+	False, True, True, True, True, True, True, True, True, True,            # 0 - 9
+	True, True, True, True, False, False, False, False, False, False,       # 10 - 19
+	False, False, False, False, False, True, False, False, False, False,    # 20 - 29
+	True, True, False, False, True, True, False, False, True, False,        # 30 - 39
+	False, True, False, False, False, False, False, False, False, False     # 40 - 49
+]
+
 ann_labels = [
     AnnotationLabel(0, " ", 'NOTANN', 'Not an actual annotation'),
     AnnotationLabel(1, "N", 'NORMAL', 'Normal beat'),

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -15,6 +15,7 @@ import pdb
 from wfdb.io import _header
 from wfdb.io import _signal
 from wfdb.io import download
+from wfdb.io import annotation
 
 
 # -------------- WFDB Signal Calibration and Classification ---------- #
@@ -4093,6 +4094,143 @@ def wfdbtime(record_name, input_times, pn_dir=None):
             sample_num = int(sum(x*60**i for i,x in enumerate([seconds,minutes,hours])) * record.fs)
         sample_num = 's' + str(sample_num)
         print(f'{sample_num:>12}{out_time:>24}{out_date:>32}')
+
+
+def sigavg(record_name, extension, pn_dir=None, return_df=False,
+           start_range=-0.05, stop_range=0.05, time_start=0, time_stop=-1,
+           verbose=False):
+    """
+    A common problem in signal processing is to determine the shape of a
+    recurring waveform in the presence of noise. If the waveform recurs
+    periodically (for example, once per second) the signal can be divided into
+    segments of an appropriate length (one second in this example), and the
+    segments can be averaged to reduce the amplitude of any noise that is
+    uncorrelated with the signal. Typically, noise is reduced by a factor of
+    the square root of the number of segments included in the average. For
+    physiologic signals, the waveforms of interest are usually not strictly
+    periodic, however. This function averages such waveforms by defining
+    segments (averaging windows) relative to the locations of waveform
+    annotations. By default, all QRS (beat) annotations for the specified
+    annotator are included.
+
+    Parameters
+    ----------
+    record_name : str
+        The name of the WFDB record to be read, without any file
+        extensions. If the argument contains any path delimiter
+        characters, the argument will be interpreted as PATH/BASE_RECORD.
+        Both relative and absolute paths are accepted. If the `pn_dir`
+        parameter is set, this parameter should contain just the base
+        record name, and the files fill be searched for remotely.
+        Otherwise, the data files will be searched for in the local path.
+    pn_dir : str, optional
+        Option used to stream data from Physionet. The Physionet
+        database directory from which to find the required record files.
+        eg. For record '100' in 'http://physionet.org/content/mitdb'
+        pn_dir='mitdb'.
+    return_df : bool, optional
+        Whether to return a Pandas dataframe (True) or just print the output
+        (False).
+    start_range : float, int, optional
+        Set the measurement window relative to QRS annotations. Negative
+        values correspond to offsets that precede the annotations. The default
+        is -0.05 seconds.
+    stop_range : float, int, optional
+        Set the measurement window relative to QRS annotations. Negative
+        values correspond to offsets that precede the annotations. The default
+        is 0.05 seconds.
+    time_start : float, int, optional
+        Begin at the specified time in record. The default is 0 which denotes
+        the start of the record.
+    time_stop : float, int, optional
+        Process until the specified time in record. The default is -1 which
+        denotes the end of the record.
+    verbose : bool, optional
+        Whether to print the headers (True) or not (False).
+
+    Returns
+    -------
+    N/A : Pandas dataframe
+        If `return_df` is set to True, return a Pandas dataframe representing
+        the output from the original WFDB package. This is the same content as
+        if `return_df` were set to False, just in dataframe form.
+
+    """
+    if start_range >= stop_range:
+        raise Exception('`start_range` must be less than `stop_range`')
+    if time_start == time_stop:
+        raise Exception('`time_start` must be different than `time_stop`')
+    if (time_stop != -1) and (time_start >= time_stop):
+        raise Exception('`time_start` must be less than `time_stop`')
+    if time_start < 0:
+        raise Exception('`time_start` must be at least 0')
+    if (time_stop != -1) and (time_stop <= 0):
+        raise Exception('`time_stop` must be at least greater than 0')
+
+    if (pn_dir is not None) and ('.' not in pn_dir):
+        dir_list = pn_dir.split('/')
+        pn_dir = posixpath.join(dir_list[0], get_version(dir_list[0]),
+                                *dir_list[1:])
+
+    rec = rdrecord(record_name, pn_dir=pn_dir, physical=False)
+    ann = annotation.rdann(record_name, extension)
+
+    if time_stop == -1:
+        time_stop = max(ann.sample) / ann.fs
+    samp_start = int(time_start * ann.fs)
+    samp_stop = int(time_stop * ann.fs)
+    filtered_samples = ann.sample[(ann.sample>=samp_start) & (ann.sample<=samp_stop)]
+
+    times = np.arange(int(start_range*rec.fs) / rec.fs,
+                      int(-(-stop_range // (1/rec.fs))) / rec.fs,
+                      1/rec.fs)
+    indices = np.rint(times*rec.fs).astype(np.int64)
+
+    n_beats = 0
+    initial_sig_avgs = np.zeros((times.shape[0],rec.n_sig))
+    for samp in filtered_samples:
+        samp_i = np.where(ann.sample==samp)[0][0]
+
+        all_symbols = [a.symbol for a in annotation.ann_labels]
+        try:
+            if not annotation.is_qrs[all_symbols.index(ann.symbol[samp_i])]:
+                continue
+        except ValueError:
+            continue
+
+        for c,i in enumerate(indices):
+            for j in range(rec.n_sig):
+                try:
+                    initial_sig_avgs[c][j] += rec.d_signal[samp+i][j]
+                except IndexError:
+                    initial_sig_avgs[c][j] += 0
+        n_beats += 1
+
+    if n_beats < 1:
+        raise Exception('No beats found')
+
+    if verbose and not return_df:
+        print(f'# Average of {n_beats} beats:')
+        s = '{:>14}' * rec.n_sig
+        print(f'#        Time{s.format(*rec.sig_name)}')
+        print(f'#         sec{s.format(*rec.units)}')
+
+    final_sig_avgs = []
+    for i,time in enumerate(times):
+        sig_avgs = []
+        for j in range(rec.n_sig):
+            temp_sig_avg = initial_sig_avgs[i][j]/n_beats
+            temp_sig_avg -= rec.baseline[j]
+            temp_sig_avg /= rec.adc_gain[j]
+            sig_avgs.append(round(temp_sig_avg,5))
+        final_sig_avgs.append(sig_avgs)
+
+    df = pd.DataFrame(final_sig_avgs, columns=rec.sig_name)
+    df.insert(0, 'Time', np.around(times,decimals=5))
+    if return_df:
+        return df
+    else:
+        print(df.to_string(index=False, header=False, col_space=13))
 
 
 def _get_date_from_time(start_time, hours, minutes, seconds, out_time):


### PR DESCRIPTION
This change add the `sigavg` function from the [original WFDB package](https://physionet.org/physiotools/wag/sigavg-1.htm). So far, I have included the `-d`, `-f`, `-t`, and `-v` flags with intentions to add the flags ~~`-p`~~ (done in 7ed6c24) and `-z` before merging. For this implementation I decided to allow the user to both print the output like in the original package and return it as a Pandas dataframe for easy lookup and access when piping it to another function.