### PR TITLE
bugfix: unable to plot single channel record

### DIFF
--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,0 +1,31 @@
+import wfdb
+from wfdb.plot import plot
+import unittest
+
+class TestPlot(unittest.TestCase):
+
+    def test_get_plot_dims(self):
+        sampfrom = 0
+        sampto = 3000
+        record = wfdb.rdrecord('sample-data/100', physical=True, sampfrom=sampfrom, sampto=sampto)
+        ann = wfdb.rdann('sample-data/100', 'atr', sampfrom=sampfrom, sampto=sampto)
+        sig_len, n_sig, n_annot, n_subplots = plot.get_plot_dims(signal=record.p_signal, ann_samp=[ann.sample])
+
+        assert sig_len == sampto - sampfrom
+        assert n_sig == record.n_sig
+        assert n_annot == 1
+        assert n_subplots == record.n_sig
+
+    def test_create_figure_single_subplots(self):
+        n_subplots = 1
+        fig, axes = plot.create_figure(n_subplots, sharex=True, sharey=True, figsize=None)
+        assert fig is not None
+        assert axes is not None
+        assert len(axes) == n_subplots
+
+    def test_create_figure_multiple_subplots(self):
+        n_subplots = 5
+        fig, axes = plot.create_figure(n_subplots, sharex=True, sharey=True, figsize=None)
+        assert fig is not None
+        assert axes is not None
+        assert len(axes) == n_subplots

--- a/wfdb/plot/plot.py
+++ b/wfdb/plot/plot.py
@@ -230,6 +230,8 @@ def create_figure(n_subplots, sharex, sharey, figsize):
     fig, axes = plt.subplots(
         nrows=n_subplots, ncols=1, sharex=sharex, sharey=sharey, figsize=figsize
     )
+    if n_subplots == 1:
+        axes = [axes]
     return fig, axes
 
 


### PR DESCRIPTION
## Problem:
Unable to plot a record with only one channel

## Cause:

In `plot.py`: `plot_signal()`, `plot_annotation()` and `plot_ecg_grids()` uses `axes` as lists, e.g. :

```python
# in plot.py: plot_signal():

    # Plot the signals
    if signal.ndim == 1:
        axes[0].plot(t, signal, sig_style[0], zorder=3)

```

## Steps to reproduce: 

```python
>>> import wfdb
>>> record = wfdb.rdrecord('sample-data/100', sampto=3000)
>>> wfdb.plot_wfdb(record)
# This figure is well-plotted

# now try the same record, with only one channel:
>>> record2 = wfdb.rdrecord('sample-data/100', sampto=3000, channel_names=['V5']) 
>>> wfdb.plot_wfdb(record2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\git\wfdb-python\wfdb\plot\plot.py", line 642, in plot_wfdb
    return plot_items(signal=signal, ann_samp=ann_samp, ann_sym=ann_sym, fs=fs,
  File "C:\git\wfdb-python\wfdb\plot\plot.py", line 119, in plot_items
    plot_signal(signal, sig_len, n_sig, fs, time_units, sig_style, axes)       
  File "C:\git\wfdb-python\wfdb\plot\plot.py", line 283, in plot_signal        
    axes[ch].plot(t, signal[:,ch], sig_style[ch], zorder=3)
TypeError: 'AxesSubplot' object is not subscriptable

```

## Fix:

Return a list manually if `n_subplots == 1`
