### PR TITLE
Lazily import matplotlib

### DIFF
--- a/wfdb/plot/plot.py
+++ b/wfdb/plot/plot.py
@@ -1,4 +1,3 @@
-import matplotlib.pyplot as plt
 import numpy as np
 import os
 import pdb
@@ -109,6 +108,8 @@ def plot_items(signal=None, ann_samp=None, ann_sym=None, fs=None,
                         figsize=(10,4), ecg_grids='all')
 
     """
+    import matplotlib.pyplot as plt
+
     # Figure out number of subplots required
     sig_len, n_sig, n_annot, n_subplots = get_plot_dims(signal, ann_samp)
 
@@ -227,6 +228,8 @@ def create_figure(n_subplots, sharex, sharey, figsize):
     axes : list
         The information needed for each subplot.
     """
+    import matplotlib.pyplot as plt
+
     fig, axes = plt.subplots(
         nrows=n_subplots, ncols=1, sharex=sharex, sharey=sharey, figsize=figsize
     )

--- a/wfdb/processing/evaluate.py
+++ b/wfdb/processing/evaluate.py
@@ -1,6 +1,5 @@
 from multiprocessing import cpu_count, Pool
 
-import matplotlib.pyplot as plt
 import numpy as np
 import requests
 
@@ -317,6 +316,8 @@ class Comparitor(object):
             The axes information for the plot.
 
         """
+        import matplotlib.pyplot as plt
+
         fig = plt.figure(figsize=figsize)
         ax = fig.add_subplot(1, 1, 1)
 


### PR DESCRIPTION
Importing the 'matplotlib' library does all kinds of crazy stuff (such as crashing, sometimes, depending on what other packages are/aren't installed and whether or not DISPLAY is set), and makes startup significantly slower.  If your program is not actually doing anything involving plotting, this unpredictability and slowness is a nuisance.

Thus, only import the library in functions that use it.
