### PR TITLE
Optimize smooth_frames=False

### DIFF
--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -1193,12 +1193,13 @@ def _rd_dat_signals(file_name, dir_name, pn_dir, fmt, n_sig, sig_len,
         # List of 1d numpy arrays
         signal = []
         # Transfer over samples
+        sig_frames = sig_data.reshape(-1, tsamps_per_frame)
+        ch_start = 0
         for ch in range(n_sig):
-            # Indices of the flat signal that belong to the channel
-            ch_indices = np.concatenate([np.array(range(samps_per_frame[ch]))
-                                         + sum([0] + samps_per_frame[:ch])
-                                         + tsamps_per_frame * framenum for framenum in range(int(len(sig_data)/tsamps_per_frame))])
-            signal.append(sig_data[ch_indices])
+            ch_end = ch_start + samps_per_frame[ch]
+            ch_signal = sig_frames[:, ch_start:ch_end].reshape(-1)
+            signal.append(ch_signal)
+            ch_start = ch_end
         # Skew the signal
         signal = _skew_sig(signal, skew, n_sig, read_len, fmt, nan_replace, samps_per_frame)
 


### PR DESCRIPTION
If we are reading a record in "non-smooth-frames" mode, we need to extract an array of samples for each signal, which may require copying a non-contiguous sequence of samples into a new array.

Previously, this was done through a complicated Python loop that created an array of all the desired sample indices (i.e., if the signal contains 1,000,000 samples, this would generate an array of 1,000,000 integers) and using that array to index into the raw sample array.  This is rather slow.

A better way is to treat the raw sample array as a 2D array, extract a slice, and then reshape that slice into a 1D array.  This means the work is done within numpy and is very fast.

This shouldn't have any user-visible effects, apart from better performance, and is independent of pull #313.

Example:

```
$ git checkout master

$ time python3 -c 'import wfdb;[wfdb.rdrecord("sample-data/wave_4",smooth_frames=True) for _ in range(10)]'

real    0m2.009s
user    0m1.892s
sys     0m0.112s

$ time python3 -c 'import wfdb;[wfdb.rdrecord("sample-data/wave_4",smooth_frames=False) for _ in range(10)]'

real    0m7.895s
user    0m7.591s
sys     0m0.301s

$ git checkout optimize-non-smooth

$ time python3 -c 'import wfdb;[wfdb.rdrecord("sample-data/wave_4",smooth_frames=True) for _ in range(10)]'

real    0m1.952s
user    0m1.877s
sys     0m0.122s

$ time python3 -c 'import wfdb;[wfdb.rdrecord("sample-data/wave_4",smooth_frames=False) for _ in range(10)]'

real    0m0.883s
user    0m0.778s
sys     0m0.169s
```
