### PR TITLE
Allow hyphens in segment names, and fix basic parsing issues

### DIFF
--- a/wfdb/io/_header.py
+++ b/wfdb/io/_header.py
@@ -882,6 +882,8 @@ def _parse_record_line(record_line):
 
     # Read string fields from record line
     match = _rx_record.match(record_line)
+    if match is None:
+        raise HeaderSyntaxError('invalid syntax in record line')
     (record_fields['record_name'], record_fields['n_seg'],
      record_fields['n_sig'], record_fields['fs'],
      record_fields['counter_freq'], record_fields['base_counter'],
@@ -946,6 +948,8 @@ def _parse_signal_lines(signal_lines):
     # Read string fields from signal line
     for ch in range(n_sig):
         match = _rx_signal.match(signal_lines[ch])
+        if match is None:
+            raise HeaderSyntaxError('invalid syntax in signal line')
         (signal_fields['file_name'][ch], signal_fields['fmt'][ch],
          signal_fields['samps_per_frame'][ch], signal_fields['skew'][ch],
          signal_fields['byte_offset'][ch], signal_fields['adc_gain'][ch],
@@ -1003,6 +1007,8 @@ def _read_segment_lines(segment_lines):
     # Read string fields from signal line
     for i in range(len(segment_lines)):
         match = _rx_segment.match(segment_lines[i])
+        if match is None:
+            raise HeaderSyntaxError('invalid syntax in segment line')
         (segment_fields['seg_name'][i],
          segment_fields['seg_len'][i]) = match.groups()
 
@@ -1011,6 +1017,10 @@ def _read_segment_lines(segment_lines):
             segment_fields['seg_len'][i] = int(segment_fields['seg_len'][i])
 
     return segment_fields
+
+
+class HeaderSyntaxError(ValueError):
+    """Invalid syntax found in a WFDB header file."""
 
 
 def lines_to_file(file_name, write_dir, lines):

--- a/wfdb/io/_header.py
+++ b/wfdb/io/_header.py
@@ -100,29 +100,34 @@ FIELD_SPECS = pd.concat((RECORD_SPECS, SIGNAL_SPECS, SEGMENT_SPECS))
 
 # Regexp objects for reading headers
 # Record line
-_rx_record = re.compile(''.join(
-    ["[ \t]*",
-     "(?P<record_name>[-\w]+)/?(?P<n_seg>\d*)[ \t]+",
-     "(?P<n_sig>\d+)[ \t]*(?P<fs>\d*\.?\d*)/*(?P<counter_freq>-?\d*\.?\d*)",
-     "\(?(?P<base_counter>-?\d*\.?\d*)\)?[ \t]*(?P<sig_len>\d*)[ \t]*",
-     "(?P<base_time>\d{,2}:?\d{,2}:?\d{,2}\.?\d{,6})[ \t]*",
-     "(?P<base_date>\d{,2}/?\d{,2}/?\d{,4})"])
-)
+_rx_record = re.compile(
+    r'''
+    [ \t]*
+    (?P<record_name>[-\w]+)/?(?P<n_seg>\d*)[ \t]+
+    (?P<n_sig>\d+)[ \t]*(?P<fs>\d*\.?\d*)/*(?P<counter_freq>-?\d*\.?\d*)
+    \(?(?P<base_counter>-?\d*\.?\d*)\)?[ \t]*(?P<sig_len>\d*)[ \t]*
+    (?P<base_time>\d{,2}:?\d{,2}:?\d{,2}\.?\d{,6})[ \t]*
+    (?P<base_date>\d{,2}/?\d{,2}/?\d{,4})
+    ''', re.VERBOSE)
 
 # Signal line
-_rx_signal = re.compile(''.join(
-    ["[ \t]*",
-     "(?P<file_name>~?[-\w]*\.?[\w]*)[ \t]+(?P<fmt>\d+)x?"
-     "(?P<samps_per_frame>\d*):?(?P<skew>\d*)\+?(?P<byte_offset>\d*)[ \t]*",
-     "(?P<adc_gain>-?\d*\.?\d*e?[\+-]?\d*)\(?(?P<baseline>-?\d*)\)?",
-     "/?(?P<units>[\w\^\-\?%\/]*)[ \t]*(?P<adc_res>\d*)[ \t]*",
-     "(?P<adc_zero>-?\d*)[ \t]*(?P<init_value>-?\d*)[ \t]*(?P<checksum>-?\d*)",
-     "[ \t]*(?P<block_size>\d*)[ \t]*(?P<sig_name>[\S]?[^\t\n\r\f\v]*)"])
-)
+_rx_signal = re.compile(
+    r'''
+    [ \t]*
+    (?P<file_name>~?[-\w]*\.?[\w]*)[ \t]+(?P<fmt>\d+)x?
+    (?P<samps_per_frame>\d*):?(?P<skew>\d*)\+?(?P<byte_offset>\d*)[ \t]*
+    (?P<adc_gain>-?\d*\.?\d*e?[\+-]?\d*)\(?(?P<baseline>-?\d*)\)?
+    /?(?P<units>[\w\^\-\?%\/]*)[ \t]*(?P<adc_res>\d*)[ \t]*
+    (?P<adc_zero>-?\d*)[ \t]*(?P<init_value>-?\d*)[ \t]*(?P<checksum>-?\d*)
+    [ \t]*(?P<block_size>\d*)[ \t]*(?P<sig_name>[\S]?[^\t\n\r\f\v]*)
+    ''', re.VERBOSE)
 
 # Segment line
-_rx_segment = re.compile('[ \t]*(?P<seg_name>[-\w]*~?)[ \t]+(?P<seg_len>\d+)')
-
+_rx_segment = re.compile(
+    r'''
+    [ \t]*
+    (?P<seg_name>[-\w]*~?)[ \t]+(?P<seg_len>\d+)
+    ''', re.VERBOSE)
 
 class BaseHeaderMixin(object):
     """

--- a/wfdb/io/_header.py
+++ b/wfdb/io/_header.py
@@ -119,7 +119,7 @@ _rx_signal = re.compile(''.join(
 )
 
 # Segment line
-_rx_segment = re.compile('(?P<seg_name>\w*~?)[ \t]+(?P<seg_len>\d+)')
+_rx_segment = re.compile('(?P<seg_name>[-\w]*~?)[ \t]+(?P<seg_len>\d+)')
 
 
 class BaseHeaderMixin(object):

--- a/wfdb/io/_header.py
+++ b/wfdb/io/_header.py
@@ -102,31 +102,41 @@ FIELD_SPECS = pd.concat((RECORD_SPECS, SIGNAL_SPECS, SEGMENT_SPECS))
 # Record line
 _rx_record = re.compile(
     r'''
-    [ \t]*
-    (?P<record_name>[-\w]+)/?(?P<n_seg>\d*)[ \t]+
-    (?P<n_sig>\d+)[ \t]*(?P<fs>\d*\.?\d*)/*(?P<counter_freq>-?\d*\.?\d*)
-    \(?(?P<base_counter>-?\d*\.?\d*)\)?[ \t]*(?P<sig_len>\d*)[ \t]*
-    (?P<base_time>\d{,2}:?\d{,2}:?\d{,2}\.?\d{,6})[ \t]*
-    (?P<base_date>\d{,2}/?\d{,2}/?\d{,4})
+    [ \t]* (?P<record_name>[-\w]+)
+           /?(?P<n_seg>\d*)
+    [ \t]+ (?P<n_sig>\d+)
+    [ \t]* (?P<fs>\d*\.?\d*)
+           /*(?P<counter_freq>-?\d*\.?\d*)
+           \(?(?P<base_counter>-?\d*\.?\d*)\)?
+    [ \t]* (?P<sig_len>\d*)
+    [ \t]* (?P<base_time>\d{,2}:?\d{,2}:?\d{,2}\.?\d{,6})
+    [ \t]* (?P<base_date>\d{,2}/?\d{,2}/?\d{,4})
     ''', re.VERBOSE)
 
 # Signal line
 _rx_signal = re.compile(
     r'''
-    [ \t]*
-    (?P<file_name>~?[-\w]*\.?[\w]*)[ \t]+(?P<fmt>\d+)x?
-    (?P<samps_per_frame>\d*):?(?P<skew>\d*)\+?(?P<byte_offset>\d*)[ \t]*
-    (?P<adc_gain>-?\d*\.?\d*e?[\+-]?\d*)\(?(?P<baseline>-?\d*)\)?
-    /?(?P<units>[\w\^\-\?%\/]*)[ \t]*(?P<adc_res>\d*)[ \t]*
-    (?P<adc_zero>-?\d*)[ \t]*(?P<init_value>-?\d*)[ \t]*(?P<checksum>-?\d*)
-    [ \t]*(?P<block_size>\d*)[ \t]*(?P<sig_name>[\S]?[^\t\n\r\f\v]*)
+    [ \t]* (?P<file_name>~?[-\w]*\.?[\w]*)
+    [ \t]+ (?P<fmt>\d+)
+           x?(?P<samps_per_frame>\d*)
+           :?(?P<skew>\d*)
+           \+?(?P<byte_offset>\d*)
+    [ \t]* (?P<adc_gain>-?\d*\.?\d*e?[\+-]?\d*)
+           \(?(?P<baseline>-?\d*)\)?
+           /?(?P<units>[\w\^\-\?%\/]*)
+    [ \t]* (?P<adc_res>\d*)
+    [ \t]* (?P<adc_zero>-?\d*)
+    [ \t]* (?P<init_value>-?\d*)
+    [ \t]* (?P<checksum>-?\d*)
+    [ \t]* (?P<block_size>\d*)
+    [ \t]* (?P<sig_name>[\S]?[^\t\n\r\f\v]*)
     ''', re.VERBOSE)
 
 # Segment line
 _rx_segment = re.compile(
     r'''
-    [ \t]*
-    (?P<seg_name>[-\w]*~?)[ \t]+(?P<seg_len>\d+)
+    [ \t]* (?P<seg_name>[-\w]*~?)
+    [ \t]+ (?P<seg_len>\d+)
     ''', re.VERBOSE)
 
 class BaseHeaderMixin(object):


### PR DESCRIPTION
* Hyphens should be permitted in segment names.  Currently hyphens are permitted in record names and signal file names, but not in segment names.

* When parsing a line in a header file, we must start at the beginning of the line.  Currently we search for the expected pattern *anywhere within the line*, which means any "junk" at the start of the line is silently ignored.

This means that if a multi-segment record includes a segment with a hyphen in the name, everything up to and including the hyphen is silently ignored.

A related problem occurs if there are slashes in a segment or signal file name.  Although subdirectories are permitted in WFDB format, wfdb-python currently doesn't support them, so these should raise an exception rather than being silently ignored.
