### PR TITLE
Fix downloading files in windows

### DIFF
--- a/wfdb/io/download.py
+++ b/wfdb/io/download.py
@@ -262,7 +262,7 @@ def get_record_list(db_dir, records='all'):
 
     """
     # Full url PhysioNet database
-    if '/' not in db_dir:
+    if os.sep not in db_dir:
         db_url = posixpath.join(config.db_index_url, db_dir, record.get_version(db_dir))
     else:
         db_url = posixpath.join(config.db_index_url, db_dir)

--- a/wfdb/io/download.py
+++ b/wfdb/io/download.py
@@ -511,10 +511,6 @@ def dl_files(db, dl_dir, files, keep_subdirs=True, overwrite=False):
     make_local_dirs(dl_dir, dl_inputs, keep_subdirs)
 
     print('Downloading files...')
-    # Create multiple processes to download files.
-    # Limit to 2 connections to avoid overloading the server
-    #pool = multiprocessing.Pool(processes=2)
-    #pool.map(dl_pn_file, dl_inputs)
     dl_pn_file(dl_inputs)
     print('Finished downloading files')
 

--- a/wfdb/io/download.py
+++ b/wfdb/io/download.py
@@ -513,8 +513,9 @@ def dl_files(db, dl_dir, files, keep_subdirs=True, overwrite=False):
     print('Downloading files...')
     # Create multiple processes to download files.
     # Limit to 2 connections to avoid overloading the server
-    pool = multiprocessing.Pool(processes=2)
-    pool.map(dl_pn_file, dl_inputs)
+    #pool = multiprocessing.Pool(processes=2)
+    #pool.map(dl_pn_file, dl_inputs)
+    dl_pn_file(dl_inputs)
     print('Finished downloading files')
 
     return

--- a/wfdb/io/download.py
+++ b/wfdb/io/download.py
@@ -262,7 +262,7 @@ def get_record_list(db_dir, records='all'):
 
     """
     # Full url PhysioNet database
-    if os.sep not in db_dir:
+    if "/" not in db_dir:
         db_url = posixpath.join(config.db_index_url, db_dir, record.get_version(db_dir))
     else:
         db_url = posixpath.join(config.db_index_url, db_dir)

--- a/wfdb/io/download.py
+++ b/wfdb/io/download.py
@@ -262,7 +262,7 @@ def get_record_list(db_dir, records='all'):
 
     """
     # Full url PhysioNet database
-    if "/" not in db_dir:
+    if '/' not in db_dir:
         db_url = posixpath.join(config.db_index_url, db_dir, record.get_version(db_dir))
     else:
         db_url = posixpath.join(config.db_index_url, db_dir)

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -4469,7 +4469,7 @@ def is_monotonic(full_list):
 
 
 def dl_database(db_dir, dl_dir, records='all', annotators='all',
-                keep_subdirs=True, overwrite=False):
+                keep_subdirs=True, overwrite=False, use_multiprocess=True):
     """
     Download WFDB record (and optionally annotation) files from a
     PhysioNet database. The database must contain a 'RECORDS' file in
@@ -4509,6 +4509,8 @@ def dl_database(db_dir, dl_dir, records='all', annotators='all',
         file is smaller, the file will be assumed to be partially
         downloaded and the remaining bytes will be downloaded and
         appended.
+   use_multiprocess : bool, optional
+        If True, multiprocess package is used to download files.
 
     Returns
     -------
@@ -4525,7 +4527,8 @@ def dl_database(db_dir, dl_dir, records='all', annotators='all',
         db_dir = posixpath.join(dir_list[0], get_version(dir_list[0]), *dir_list[1:])
     else:
         db_dir = posixpath.join(db_dir, get_version(db_dir))
-    db_url = posixpath.join(download.PN_CONTENT_URL, db_dir) + '/'
+
+    db_url = posixpath.join(download.PN_CONTENT_URL, db_dir)
     # Check if the database is valid
     _url.openurl(db_url, check_access=True)
 
@@ -4596,10 +4599,14 @@ def dl_database(db_dir, dl_dir, records='all', annotators='all',
     download.make_local_dirs(dl_dir, dl_inputs, keep_subdirs)
 
     print('Downloading files...')
-    # Create multiple processes to download files.
-    # Limit to 2 connections to avoid overloading the server
-    pool = multiprocessing.Pool(processes=2)
-    pool.map(download.dl_pn_file, dl_inputs)
+    if use_multiprocess:
+        # Create multiple processes to download files.
+        # Limit to 2 connections to avoid overloading the server
+        pool = multiprocessing.Pool(processes=2)
+        pool.map(download.dl_pn_file, dl_inputs)
+    else:
+        for input in dl_inputs:
+            download.dl_pn_file(input)
     print('Finished downloading files')
 
     return


### PR DESCRIPTION
Adding a small change to make optional the use of multiple threads for download files. We couldn't make it work in a conda environment in windows.

With this change, default is the same, but multithread download can be disabled by optional parameter. 