### PR TITLE
Eliminate "is True" and "is False"

### DIFF
--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -1891,7 +1891,7 @@ def _np_dtype(bit_res, discrete):
         if bit_res <= np_res:
             break
 
-    if discrete is True:
+    if discrete:
         return 'int' + str(np_res)
     else:
         # No float8 dtype

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -698,9 +698,9 @@ class SignalMixin(object):
         N/A
 
         """
-        if physical is True:
+        if physical:
             return_dtype = 'float'+str(return_res)
-            if smooth_frames is True:
+            if smooth_frames:
                 current_dtype = self.p_signal.dtype
                 if current_dtype != return_dtype:
                     self.p_signal = self.p_signal.astype(return_dtype, copy=False)
@@ -715,7 +715,7 @@ class SignalMixin(object):
                             self.p_signal[ch] = self.p_signal[ch].astype(return_dtype, copy=False)
         else:
             return_dtype = 'int'+str(return_res)
-            if smooth_frames is True:
+            if smooth_frames:
                 current_dtype = self.d_signal.dtype
                 if current_dtype != return_dtype:
                     # Do not allow changing integer dtype to lower value due to over/underflow

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -409,12 +409,12 @@ class BaseRecord(object):
 
         if return_res not in [64, 32, 16, 8]:
             raise ValueError("return_res must be one of the following: 64, 32, 16, 8")
-        if physical is True and return_res == 8:
+        if physical and return_res == 8:
             raise ValueError("return_res must be one of the following when physical is True: 64, 32, 16")
 
         # Cannot expand multiple samples/frame for multi-segment records
         if isinstance(self, MultiRecord):
-            if smooth_frames is False:
+            if not smooth_frames:
                 raise ValueError('This package version cannot expand all samples when reading multi-segment records. Must enable frame smoothing.')
 
 


### PR DESCRIPTION
If a parameter X is documented as having a boolean value, it should be treated (in duck-typing style) as true if bool(X) is true, or false if bool(X) is false.

Writing "if X is True" is almost always a bad idea: it suggests to the reader that "X is True" and "X is False" are the only possibilities, when in fact there is no such guarantee.

(In some cases it might make sense to explicitly check argument types to catch programming errors - but in most cases this feels like an overcomplication, and *even then* it's a bad idea to write "if X is True" because the permitted argument types might change in the future.)

To wit: `rdrecord("foo", physical=0)` would do what you expect; `rdrecord("foo", physical=1)` would crash.  `rdrecord("foo", smooth_frames=1)` would do what you expect; `rdrecord("foo", smooth_frames=0)` would crash.
