### PR TITLE
Record.convert_dtype should fail if expected data is missing

### DIFF
--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -705,14 +705,9 @@ class SignalMixin(object):
                 if current_dtype != return_dtype:
                     self.p_signal = self.p_signal.astype(return_dtype, copy=False)
             else:
-                if self.e_p_signal is not None:
-                    for ch in range(self.n_sig):
-                        if self.e_p_signal[ch].dtype != return_dtype:
-                            self.e_p_signal[ch] = self.e_p_signal[ch].astype(return_dtype, copy=False)
-                else:
-                    for ch in range(self.n_sig):
-                        if self.p_signal[ch].dtype != return_dtype:
-                            self.p_signal[ch] = self.p_signal[ch].astype(return_dtype, copy=False)
+                for ch in range(self.n_sig):
+                    if self.e_p_signal[ch].dtype != return_dtype:
+                        self.e_p_signal[ch] = self.e_p_signal[ch].astype(return_dtype, copy=False)
         else:
             return_dtype = 'int'+str(return_res)
             if smooth_frames:


### PR DESCRIPTION
This is not directly related to other issues surrounding `smooth_frames`, but a minor bug that probably doesn't affect anyone at present.

`Record.convert_dtype` can be used to change the storage format of the signal array(s).  (It's unlikely that applications will ever use this function directly and it's not included in the package documentation.)

However, if `convert_dtype` is called with `physical=True` and `smooth_frames=False`, it should convert the data type(s) of `e_p_signal`.  It shouldn't try to modify `p_signal` in this case (and the previous code would not have worked correctly either.)  If you ask to convert the data type of `e_p_signal`, and `e_p_signal` is None, this should raise an exception.
