### PR TITLE
Show annotation markers atop signals

### DIFF
--- a/wfdb/plot/plot.py
+++ b/wfdb/plot/plot.py
@@ -355,7 +355,8 @@ def plot_annotation(ann_samp, n_annot, ann_sym, signal, n_sig, fs, time_units,
                 raise Exception('IndexError: try setting shift_samps=True in ' 
                                 'the "rdann" function?')
 
-            axes[ch].plot(ann_samp[ch] / downsample_factor, y, ann_style[ch])
+            axes[ch].plot(ann_samp[ch] / downsample_factor, y, ann_style[ch],
+                          zorder=4)
 
             # Plot the annotation symbols if any
             if ann_sym is not None and ann_sym[ch] is not None:


### PR DESCRIPTION
When plotting signals and annotations using `wfdb.plot_items` or `wfdb.plot_wfdb
`, the annotation markers are currently displayed "underneath" the signal trace, where they are hard to see.  Put them "on top" instead.

For example, compare the appearance of running `wfdb.plot_wfdb(wfdb.rdrecord('sample-data/100', sampto=1000), wfdb.rdann('sample-data/100', 'qrs', sampto=1000))` before and after this change.
