### PR TITLE
Remove requirements.txt; expand workflows to include Python 3.9/3.10

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install .
       - name: Run nosetests
         run: |
           nosetests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-matplotlib==3.3.4
-nose==1.3.7
-numpy==1.18.5
-pandas==1.0.3
-requests==2.23.0
-scipy==1.4.1


### PR DESCRIPTION
Including a "requirements.txt" (or equivalent) in the repository likely suggests to users that those are the specific package versions they need to use.  That's not true.

Indeed, as this package is intended in part as a general-purpose library for applications to use (not just an application in and of itself), it's important that this package *doesn't* impose unnecessary limits on what other libraries may be co-installed with it.

So for testing purposes, it would be better to actually test a variety of *different yet stable* package versions.  'test-deb10-i386' is a start at doing that.  But in lieu of that, we should at least try to test "the latest thing available from pypi" across a variety of interpreter versions.

You may think this makes test-suite runs less reproducible... which is true.  But they weren't really reproducible *anyway* because pip would install a whole bunch of indirect dependencies automatically.  If we need to reproduce a test-suite run, we can do so (or try to) by extracting the list of installed versions from the log.
