### PR TITLE
Avoid using multiple processes for downloads

### DIFF
--- a/wfdb/io/download.py
+++ b/wfdb/io/download.py
@@ -1,4 +1,4 @@
-import multiprocessing
+import multiprocessing.dummy
 import numpy as np
 import re
 import os
@@ -539,7 +539,7 @@ def dl_files(db, dl_dir, files, keep_subdirs=True, overwrite=False):
     print("Downloading files...")
     # Create multiple processes to download files.
     # Limit to 2 connections to avoid overloading the server
-    pool = multiprocessing.Pool(processes=2)
+    pool = multiprocessing.dummy.Pool(processes=2)
     pool.map(dl_pn_file, dl_inputs)
     print("Finished downloading files")
 

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -1,5 +1,5 @@
 import datetime
-import multiprocessing
+import multiprocessing.dummy
 import posixpath
 import re
 
@@ -5279,7 +5279,7 @@ def dl_database(
     print("Downloading files...")
     # Create multiple processes to download files.
     # Limit to 2 connections to avoid overloading the server
-    pool = multiprocessing.Pool(processes=2)
+    pool = multiprocessing.dummy.Pool(processes=2)
     pool.map(download.dl_pn_file, dl_inputs)
     print("Finished downloading files")
 


### PR DESCRIPTION
`multiprocessing` is messy; it's a *pretty nifty tool* but requires you to write your entire application with multiprocessing in mind.

For simply downloading files in parallel, there's little reason to use processes rather than threads.

This *should*, though I haven't tested it, solve the issues mentioned in pull #330 and probably also issue #306.  I can't guarantee that this will solve every problem, but it should be strictly better than what we have now.
