### PR TITLE
Relax matplotlib dependency for Google Colab

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.7"
 numpy = "^1.10.1"
 scipy = "^1.0.0"
 pandas = "^1.0.0"
-matplotlib = "^3.3.4"
+matplotlib = "^3.2.2"
 requests = "^2.8.1"
 pytest = {version = "^7.1.1", optional = true}
 pytest-xdist = {version = "^2.5.0", optional = true}


### PR DESCRIPTION
Issue #374: when you create a notebook in Google Colab (https://colab.research.google.com/), it comes pre-configured with a bunch of pip packages by default.  Some of those pre-installed packages will *conflict* with what you get if you try to run `pip install --upgrade matplotlib`.

Fortunately, the pre-installed environment already includes matplotlib, just not the latest version.

AFAIK, there should not be any problem using wfdb with matplotlib 3.2.2, so we can relax this requirement to make it easier for people to use the package with Colab.

Remember, when you run `pip install wfdb` in a fresh environment, it will always give you the *latest* versions that satisfy wfdb's dependencies.  So most people running `pip install wfdb` will still get matplotlib 3.5.2.
