### PR TITLE
Add __getitem__ to Record, allowing to copy a Record using slicing.

### DIFF
--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -871,13 +871,13 @@ class Record(BaseRecord, _header.HeaderMixin, _signal.SignalMixin):
             t_idx = item
             c_idx = slice(None)
 
-        # Copy the record.
-
-        cp = copy(self.record)
-
         # Use these weird tricks to find out how numpy interprets t_idx and c_idx.
         t_idx_list = np.arange(self.record.sig_len)[t_idx]
         c_idx_list = np.arange(self.record.n_sig)[c_idx]
+
+        # Copy the record.
+
+        cp = copy(self.record)
 
         cp.sig_len = len(t_idx_list)
         cp.n_sig = len(c_idx_list)


### PR DESCRIPTION
Supports convenient slicing across both time and space.

Functions like rdrecord support subselection of time and channels already. In many cases, that is sufficient.

However, a function like this might still be useful if:

* The file is not accessible from the current function; just a Record object is.
* A copy of a record should be made, with additional channels.

### Examples

```py
copy = record[:record.fs * 60 * 30, [0, 2, 5]]
copy.sig_name = ["x", "y", "z"]
copy.record_name = f"{record.record_name}-xyz"
copy.wrsamp()
```