### PR TITLE
Add base_datetime property

### DIFF
--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -208,6 +208,7 @@ class BaseRecord(object):
         sig_len=None,
         base_time=None,
         base_date=None,
+        base_datetime=None,
         comments=None,
         sig_name=None,
     ):
@@ -217,8 +218,19 @@ class BaseRecord(object):
         self.counter_freq = counter_freq
         self.base_counter = base_counter
         self.sig_len = sig_len
-        self.base_time = base_time
-        self.base_date = base_date
+        if base_datetime is not None:
+            if base_time is not None:
+                raise TypeError(
+                    "cannot specify both base_time and base_datetime"
+                )
+            if base_date is not None:
+                raise TypeError(
+                    "cannot specify both base_date and base_datetime"
+                )
+            self.base_datetime = base_datetime
+        else:
+            self.base_time = base_time
+            self.base_date = base_date
         self.comments = comments
         self.sig_name = sig_name
 
@@ -687,6 +699,7 @@ class Record(BaseRecord, _header.HeaderMixin, _signal.SignalMixin):
         sig_len=None,
         base_time=None,
         base_date=None,
+        base_datetime=None,
         file_name=None,
         fmt=None,
         samps_per_frame=None,
@@ -716,6 +729,7 @@ class Record(BaseRecord, _header.HeaderMixin, _signal.SignalMixin):
             sig_len=sig_len,
             base_time=base_time,
             base_date=base_date,
+            base_datetime=base_datetime,
             comments=comments,
             sig_name=sig_name,
         )
@@ -972,6 +986,7 @@ class MultiRecord(BaseRecord, _header.MultiHeaderMixin):
         sig_len=None,
         base_time=None,
         base_date=None,
+        base_datetime=None,
         seg_name=None,
         seg_len=None,
         comments=None,
@@ -988,6 +1003,7 @@ class MultiRecord(BaseRecord, _header.MultiHeaderMixin):
             sig_len=sig_len,
             base_time=base_time,
             base_date=base_date,
+            base_datetime=base_datetime,
             comments=comments,
             sig_name=sig_name,
         )

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -5049,6 +5049,7 @@ def wrsamp(
     comments=None,
     base_time=None,
     base_date=None,
+    base_datetime=None,
     write_dir="",
 ):
     """
@@ -5097,6 +5098,9 @@ def wrsamp(
         The time of day at the beginning of the record.
     base_date : datetime.date, optional
         The date at the beginning of the record.
+    base_datetime : datetime.datetime, optional
+        The date and time at the beginning of the record, equivalent to
+        setting both `base_date` and `base_time`.
     write_dir : str, optional
         The directory in which to write the files.
 
@@ -5154,6 +5158,7 @@ def wrsamp(
             comments=comments,
             base_time=base_time,
             base_date=base_date,
+            base_datetime=base_datetime,
         )
         # Compute optimal fields to store the digital signal, carry out adc,
         # and set the fields.
@@ -5172,6 +5177,7 @@ def wrsamp(
             comments=comments,
             base_time=base_time,
             base_date=base_date,
+            base_datetime=base_datetime,
         )
         # Use d_signal to set the fields directly
         record.set_d_features()

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -183,10 +183,10 @@ class BaseRecord(object):
         The counter used at the start of the file.
     sig_len : int, optional
         The total length of the signal.
-    base_time : str, optional
-        A string of the record's start time in 24h 'HH:MM:SS(.ms)' format.
-    base_date : str, optional
-        A string of the record's start date in 'DD/MM/YYYY' format.
+    base_time : datetime.time, optional
+        The time of day at the beginning of the record.
+    base_date : datetime.date, optional
+        The date at the beginning of the record.
     comments : list, optional
         A list of string comments to be written to the header file.
     sig_name : str, optional
@@ -601,10 +601,10 @@ class Record(BaseRecord, _header.HeaderMixin, _signal.SignalMixin):
         The counter used at the start of the file.
     sig_len : int, optional
         The total length of the signal.
-    base_time : str, optional
-        A string of the record's start time in 24h 'HH:MM:SS(.ms)' format.
-    base_date : str, optional
-        A string of the record's start date in 'DD/MM/YYYY' format.
+    base_time : datetime.time, optional
+        The time of day at the beginning of the record.
+    base_date : datetime.date, optional
+        The date at the beginning of the record.
     file_name : str, optional
         The name of the file used for analysis.
     fmt : list, optional
@@ -901,10 +901,10 @@ class MultiRecord(BaseRecord, _header.MultiHeaderMixin):
         The counter used at the start of the file.
     sig_len : int, optional
         The total length of the signal.
-    base_time : str, optional
-        A string of the record's start time in 24h 'HH:MM:SS(.ms)' format.
-    base_date : str, optional
-        A string of the record's start date in 'DD/MM/YYYY' format.
+    base_time : datetime.time, optional
+        The time of day at the beginning of the record.
+    base_date : datetime.date, optional
+        The date at the beginning of the record.
     seg_name : str, optional
         The name of the segment.
     seg_len : int, optional
@@ -5053,10 +5053,10 @@ def wrsamp(
         A list of integers specifying the digital baseline.
     comments : list, optional
         A list of string comments to be written to the header file.
-    base_time : str, optional
-        A string of the record's start time in 24h 'HH:MM:SS(.ms)' format.
-    base_date : str, optional
-        A string of the record's start date in 'DD/MM/YYYY' format.
+    base_time : datetime.time, optional
+        The time of day at the beginning of the record.
+    base_date : datetime.date, optional
+        The date at the beginning of the record.
     write_dir : str, optional
         The directory in which to write the files.
 

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -682,16 +682,16 @@ class Record(BaseRecord, _header.HeaderMixin, _signal.SignalMixin):
         # have this field. Even n_seg = 1 makes the header a multi-segment
         # header.
         super(Record, self).__init__(
-            record_name,
-            n_sig,
-            fs,
-            counter_freq,
-            base_counter,
-            sig_len,
-            base_time,
-            base_date,
-            comments,
-            sig_name,
+            record_name=record_name,
+            n_sig=n_sig,
+            fs=fs,
+            counter_freq=counter_freq,
+            base_counter=base_counter,
+            sig_len=sig_len,
+            base_time=base_time,
+            base_date=base_date,
+            comments=comments,
+            sig_name=sig_name,
         )
 
         self.p_signal = p_signal
@@ -951,16 +951,16 @@ class MultiRecord(BaseRecord, _header.MultiHeaderMixin):
     ):
 
         super(MultiRecord, self).__init__(
-            record_name,
-            n_sig,
-            fs,
-            counter_freq,
-            base_counter,
-            sig_len,
-            base_time,
-            base_date,
-            comments,
-            sig_name,
+            record_name=record_name,
+            n_sig=n_sig,
+            fs=fs,
+            counter_freq=counter_freq,
+            base_counter=base_counter,
+            sig_len=sig_len,
+            base_time=base_time,
+            base_date=base_date,
+            comments=comments,
+            sig_name=sig_name,
         )
 
         self.layout = layout

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -565,12 +565,7 @@ class BaseRecord(object):
         if sampfrom:
             dt_seconds = sampfrom / self.fs
             if self.base_date and self.base_time:
-                self.base_datetime = datetime.datetime.combine(
-                    self.base_date, self.base_time
-                )
                 self.base_datetime += datetime.timedelta(seconds=dt_seconds)
-                self.base_date = self.base_datetime.date()
-                self.base_time = self.base_datetime.time()
             # We can calculate the time even if there is no date
             elif self.base_time:
                 tmp_datetime = datetime.datetime.combine(

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -187,6 +187,9 @@ class BaseRecord(object):
         The time of day at the beginning of the record.
     base_date : datetime.date, optional
         The date at the beginning of the record.
+    base_datetime : datetime.datetime, optional
+        The date and time at the beginning of the record, equivalent to
+        `datetime.combine(base_date, base_time)`.
     comments : list, optional
         A list of string comments to be written to the header file.
     sig_name : str, optional
@@ -218,6 +221,26 @@ class BaseRecord(object):
         self.base_date = base_date
         self.comments = comments
         self.sig_name = sig_name
+
+    @property
+    def base_datetime(self):
+        if self.base_date is None or self.base_time is None:
+            return None
+        else:
+            return datetime.datetime.combine(
+                date=self.base_date, time=self.base_time
+            )
+
+    @base_datetime.setter
+    def base_datetime(self, value):
+        if value is None:
+            self.base_date = None
+            self.base_time = None
+        elif isinstance(value, datetime.datetime) and value.tzinfo is None:
+            self.base_date = value.date()
+            self.base_time = value.time()
+        else:
+            raise TypeError(f"invalid base_datetime value: {value!r}")
 
     def check_field(self, field, required_channels="all"):
         """
@@ -605,6 +628,9 @@ class Record(BaseRecord, _header.HeaderMixin, _signal.SignalMixin):
         The time of day at the beginning of the record.
     base_date : datetime.date, optional
         The date at the beginning of the record.
+    base_datetime : datetime.datetime, optional
+        The date and time at the beginning of the record, equivalent to
+        `datetime.combine(base_date, base_time)`.
     file_name : str, optional
         The name of the file used for analysis.
     fmt : list, optional
@@ -905,6 +931,9 @@ class MultiRecord(BaseRecord, _header.MultiHeaderMixin):
         The time of day at the beginning of the record.
     base_date : datetime.date, optional
         The date at the beginning of the record.
+    base_datetime : datetime.datetime, optional
+        The date and time at the beginning of the record, equivalent to
+        `datetime.combine(base_date, base_time)`.
     seg_name : str, optional
         The name of the segment.
     seg_len : int, optional


### PR DESCRIPTION
`wfdb.rdrecord` currently sets an undocumented attribute `base_datetime`, but only if the record has a base date and a base time.

```
>>> r = wfdb.rdrecord('sample-data/n16')
>>> r.base_time
datetime.time(22, 34, 47)
>>> r.base_date
datetime.date(2006, 1, 1)
>>> r.base_datetime
datetime.datetime(2006, 1, 1, 22, 34, 47)

>>> r2 = wfdb.rdrecord('sample-data/3000003_0003')
>>> r2.base_time
datetime.time(19, 46, 25, 757000)
>>> r2.base_date
>>> r2.base_datetime
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'Record' object has no attribute 'base_datetime'
```

It is frequently convenient to have this attribute available, so:

1. Always set `base_datetime`; set it to None if either `base_date` or `base_time` is None.

2. Define it as an aliased property so that setting `base_date` and `base_time` implicitly sets `base_datetime` and vice versa.

3. For consistency, also accept `base_datetime` as an argument to `wfdb.Record`, `wfdb.MultiRecord`, and `wfdb.wrsamp`.

Also, fix the documentation that incorrectly claimed `base_date` and `base_time` were strings.  They weren't.
