### PR TITLE
Convenience methods for time conversion

### DIFF
--- a/docs/io.rst
+++ b/docs/io.rst
@@ -12,10 +12,12 @@ WFDB Records
     :members: rdrecord, rdheader, rdsamp, wrsamp
 
 .. autoclass:: wfdb.io.Record
-    :members: wrsamp, adc, dac
+    :members: get_frame_number, get_elapsed_time, get_absolute_time,
+              wrsamp, adc, dac
 
 .. autoclass:: wfdb.io.MultiRecord
-    :members: multi_to_single
+    :members: get_frame_number, get_elapsed_time, get_absolute_time,
+              multi_to_single
 
 
 WFDB Anotations

--- a/docs/wfdb.rst
+++ b/docs/wfdb.rst
@@ -12,10 +12,12 @@ WFDB Records
     :members: rdrecord, rdheader, rdsamp, wrsamp
 
 .. autoclass:: wfdb.Record
-    :members: wrsamp, adc, dac
+    :members: get_frame_number, get_elapsed_time, get_absolute_time,
+              wrsamp, adc, dac
 
 .. autoclass:: wfdb.MultiRecord
-    :members: multi_to_single
+    :members: get_frame_number, get_elapsed_time, get_absolute_time,
+              multi_to_single
 
 
 WFDB Anotations


### PR DESCRIPTION
Add some convenience methods for converting between different representations of time:

- frame number (represented as an integer or float)
- elapsed time (represented as a timedelta)
- absolute time (represented as a datetime)

For example, if I want to see the signals for MIMIC-III patient 44083, between `2112-05-04 20:00:00` and `2112-05-04 20:05:00`, I might do this:

```
>>> rec_name = 'p044083-2112-05-04-19-50'
>>> pn_dir = 'mimic3wdb-matched/1.0/p04/p044083'
>>> header = wfdb.rdheader(rec_name, pn_dir=pn_dir)
>>> dt1 = datetime.datetime.fromisoformat('2112-05-04 20:00:00')
>>> dt2 = datetime.datetime.fromisoformat('2112-05-04 20:05:00')
>>> start = round(header.get_frame_number(dt1))
>>> end = round(header.get_frame_number(dt2))
>>> chunk = wfdb.rdrecord(rec_name, pn_dir=pn_dir, sampfrom=start, sampto=end)
>>> wfdb.plot_wfdb(chunk)
```
