### PR TITLE
Align signals horizontally in plot_wfdb (if possible)

### DIFF
--- a/wfdb/plot/plot.py
+++ b/wfdb/plot/plot.py
@@ -863,6 +863,7 @@ def plot_wfdb(
     ecg_grids=[],
     figsize=None,
     return_fig=False,
+    sharex="auto",
 ):
     """
     Subplot individual channels of a WFDB record and/or annotation.
@@ -917,6 +918,12 @@ def plot_wfdb(
         'figsize' argument passed into matplotlib.pyplot's `figure` function.
     return_fig : bool, optional
         Whether the figure is to be returned as an output argument.
+    sharex : bool or 'auto', optional
+        Whether the X axis should be shared between all subplots.  If set
+        to True, then all signals will be aligned with each other.  If set
+        to False, then each subplot can be panned/zoomed independently.  If
+        set to 'auto' (default), then the X axis will be shared unless
+        record is multi-frequency and the time units are set to 'samples'.
 
     Returns
     -------
@@ -954,6 +961,21 @@ def plot_wfdb(
     else:
         sampling_freq = None
 
+    if sharex == "auto":
+        # If the sampling frequencies are equal, or if we are using
+        # hours/minutes/seconds as the time unit, then share the X axes so
+        # that the channels are synchronized.  If time units are 'samples'
+        # and sampling frequencies are not uniform, then sharing X axes
+        # doesn't work and may even be misleading.
+        if (
+            time_units == "samples"
+            and isinstance(sampling_freq, list)
+            and any(f != sampling_freq[0] for f in sampling_freq)
+        ):
+            sharex = False
+        else:
+            sharex = True
+
     if annotation and annotation.fs is not None:
         ann_freq = annotation.fs
     elif record:
@@ -977,6 +999,7 @@ def plot_wfdb(
         return_fig=return_fig,
         sampling_freq=sampling_freq,
         ann_freq=ann_freq,
+        sharex=sharex,
     )
 
 

--- a/wfdb/plot/plot.py
+++ b/wfdb/plot/plot.py
@@ -856,7 +856,7 @@ def plot_wfdb(
     record=None,
     annotation=None,
     plot_sym=False,
-    time_units="samples",
+    time_units="seconds",
     title=None,
     sig_style=[""],
     ann_style=["r*"],


### PR DESCRIPTION
In `plot_wfdb`, add an argument `sharex` which controls whether X axes are shared between subplots.

(This means that multiple channels will always appear time-aligned with each other, even if one channel starts or ends with a block of NaNs.  It also means that if you use the pan/zoom buttons to navigate, the channels will *stay* aligned with each other.)

`sharex=True` is generally desirable behavior; however, if the time units are *sample numbers* and the record is multi-frequency, then it's not possible (AFAICT) with matplotlib to have the axes synchronized while displaying different units on different subplots.  So we disable sharex by default in that case.

Finally, `plot_wfdb` will use `time_units="seconds"` by default, which I think is useful because it's consistent (across databases) and familiar.

(original pull request description follows)

<s>A few changes to improve plotting of multiple channels and multiple frequencies:</s>

- <s>For `plot_items` and various internal functions, rename the `fs` argument to `frame_freq` so it is (perhaps) more clear what it means for multi-frequency data.  (I'm still not completely satisfied and think `plot_items` is harder to use than it needs to be.)</s>

- <s>Allow specifying `time_units="frames"` as an alternative to "samples", "seconds", etc.</s>

- <s>The big change: `plot_wfdb` uses `sharex=True`.  This means that multiple channels will always appear time-aligned with each other, even if one channel starts or ends with a block of NaNs.  It also means that if you use the pan/zoom buttons to navigate, the channels will *stay* aligned with each other.</s>

- <s>`plot_wfdb` will use `time_units="seconds"` by default, which I think is useful because it's consistent (across databases) and familiar.</s>

(fixes issue #373)
