### PR TITLE
Add a missing import in _coreio.py

### DIFF
--- a/wfdb/io/_coreio.py
+++ b/wfdb/io/_coreio.py
@@ -1,6 +1,7 @@
 import posixpath
 
 from wfdb.io import _url
+from wfdb.io.download import config
 
 
 def _open_file(

--- a/wfdb/io/_coreio.py
+++ b/wfdb/io/_coreio.py
@@ -1,3 +1,5 @@
+import posixpath
+
 from wfdb.io import _url
 
 


### PR DESCRIPTION
The posixpath module is used in _coreio.py but I mistakenly forgot to import it.  This breaks remote FLAC file access.
