### PR TITLE
Avoid ambiguous backslashes in regular expression strings

### DIFF
--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -44,7 +44,7 @@ class TestAnnotation(unittest.TestCase):
         target_aux_note = [None] * nannot
 
         RXannot = re.compile(
-            "[ \t]*(?P<time>[\[\]\w\.:]+) +(?P<sample>\d+) +(?P<symbol>.) +(?P<subtype>\d+) +(?P<chan>\d+) +(?P<num>\d+)\t?(?P<aux_note>.*)"
+            r"[ \t]*(?P<time>[\[\]\w\.:]+) +(?P<sample>\d+) +(?P<symbol>.) +(?P<subtype>\d+) +(?P<chan>\d+) +(?P<num>\d+)\t?(?P<aux_note>.*)"
         )
 
         for i in range(0, nannot):
@@ -117,7 +117,7 @@ class TestAnnotation(unittest.TestCase):
         target_aux_note = [None] * nannot
 
         RXannot = re.compile(
-            "[ \t]*(?P<time>[\[\]\w\.:]+) +(?P<sample>\d+) +(?P<symbol>.) +(?P<subtype>\d+) +(?P<chan>\d+) +(?P<num>\d+)\t?(?P<aux_note>.*)"
+            r"[ \t]*(?P<time>[\[\]\w\.:]+) +(?P<sample>\d+) +(?P<symbol>.) +(?P<subtype>\d+) +(?P<chan>\d+) +(?P<num>\d+)\t?(?P<aux_note>.*)"
         )
 
         for i in range(0, nannot):
@@ -188,7 +188,7 @@ class TestAnnotation(unittest.TestCase):
         target_aux_note = [None] * nannot
 
         RXannot = re.compile(
-            "[ \t]*(?P<time>[\[\]\w\.:]+) +(?P<sample>\d+) +(?P<symbol>.) +(?P<subtype>\d+) +(?P<chan>\d+) +(?P<num>\d+)\t?(?P<aux_note>.*)"
+            r"[ \t]*(?P<time>[\[\]\w\.:]+) +(?P<sample>\d+) +(?P<symbol>.) +(?P<subtype>\d+) +(?P<chan>\d+) +(?P<num>\d+)\t?(?P<aux_note>.*)"
         )
 
         for i in range(0, nannot):

--- a/wfdb/io/annotation.py
+++ b/wfdb/io/annotation.py
@@ -385,7 +385,7 @@ class Annotation(object):
 
         # Field specific checks
         if field == "record_name":
-            if bool(re.search("[^-\w]", self.record_name)):
+            if bool(re.search(r"[^-\w]", self.record_name)):
                 raise ValueError(
                     "record_name must only comprise of letters, digits, hyphens, and underscores."
                 )
@@ -2385,9 +2385,9 @@ def update_extra_fields(subtype, chan, num, aux_note, update):
     return subtype, chan, num, aux_note
 
 
-rx_fs = re.compile("## time resolution: (?P<fs>\d+\.?\d*)")
+rx_fs = re.compile(r"## time resolution: (?P<fs>\d+\.?\d*)")
 rx_custom_label = re.compile(
-    "(?P<label_store>\d+) (?P<symbol>\S+) (?P<description>.+)"
+    r"(?P<label_store>\d+) (?P<symbol>\S+) (?P<description>.+)"
 )
 
 

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -421,7 +421,7 @@ class BaseRecord(object):
         # Record specification fields
         elif field == "record_name":
             # Allow letters, digits, hyphens, and underscores.
-            accepted_string = re.match("[-\w]+", self.record_name)
+            accepted_string = re.match(r"[-\w]+", self.record_name)
             if (
                 not accepted_string
                 or accepted_string.string != self.record_name
@@ -461,7 +461,7 @@ class BaseRecord(object):
 
                 if field == "file_name":
                     # Check for file_name characters
-                    accepted_string = re.match("[-\w]+\.?[\w]+", item[ch])
+                    accepted_string = re.match(r"[-\w]+\.?[\w]+", item[ch])
                     if (
                         not accepted_string
                         or accepted_string.string != item[ch]
@@ -505,7 +505,7 @@ class BaseRecord(object):
                             "baseline values must be between -2147483648 (-2^31) and 2147483647 (2^31 -1)"
                         )
                 elif field == "units":
-                    if re.search("\s", item[ch]):
+                    if re.search(r"\s", item[ch]):
                         raise ValueError(
                             "units strings may not contain whitespaces."
                         )
@@ -520,7 +520,7 @@ class BaseRecord(object):
                             "block_size values must be non-negative integers"
                         )
                 elif field == "sig_name":
-                    if re.search("\s", item[ch]):
+                    if re.search(r"\s", item[ch]):
                         raise ValueError(
                             "sig_name strings may not contain whitespaces."
                         )
@@ -534,7 +534,7 @@ class BaseRecord(object):
                     # Segment names must be alphanumerics or just a single '~'
                     if item[ch] == "~":
                         continue
-                    accepted_string = re.match("[-\w]+", item[ch])
+                    accepted_string = re.match(r"[-\w]+", item[ch])
                     if (
                         not accepted_string
                         or accepted_string.string != item[ch]


### PR DESCRIPTION

@tompollard found that ambiguous backslashes give DeprecationWarnings on his system.

(Not that I think there is any danger of this behavior changing in python, but I think it's fair to say this syntax is confusing and should be avoided.)

I.e.: `"\s\n"` is a three-character string (equal to `"\\s\n"`).  If what you mean is `"\\s\n"`, it's better to write that and be unambiguous.

`r"\s\n"` is a four-character string (`"\\s\\n"`) but is interpreted by `re.compile` as equivalent to `"\\s\n"`.  So when writing regular expression patterns it's best to use `r` strings if possible.
