### PR TITLE
Round sample values in physical-to-digital conversion

### DIFF
--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -548,6 +548,7 @@ class SignalMixin(object):
                         self.baseline[ch],
                         self.e_p_signal[ch],
                     )
+                    np.round(self.e_p_signal[ch], 0, self.e_p_signal[ch])
                     self.e_p_signal[ch] = self.e_p_signal[ch].astype(
                         intdtype, copy=False
                     )
@@ -558,6 +559,7 @@ class SignalMixin(object):
                 nanlocs = np.isnan(self.p_signal)
                 np.multiply(self.p_signal, self.adc_gain, self.p_signal)
                 np.add(self.p_signal, self.baseline, self.p_signal)
+                np.round(self.p_signal, 0, self.p_signal)
                 self.p_signal = self.p_signal.astype(intdtype, copy=False)
                 self.d_signal = self.p_signal
                 self.p_signal = None
@@ -572,6 +574,7 @@ class SignalMixin(object):
                     ch_d_signal = self.e_p_signal[ch].copy()
                     np.multiply(ch_d_signal, self.adc_gain[ch], ch_d_signal)
                     np.add(ch_d_signal, self.baseline[ch], ch_d_signal)
+                    np.round(ch_d_signal, 0, ch_d_signal)
                     ch_d_signal = ch_d_signal.astype(intdtype, copy=False)
                     ch_d_signal[ch_nanlocs] = d_nans[ch]
                     d_signal.append(ch_d_signal)
@@ -582,6 +585,7 @@ class SignalMixin(object):
                 d_signal = self.p_signal.copy()
                 np.multiply(d_signal, self.adc_gain, d_signal)
                 np.add(d_signal, self.baseline, d_signal)
+                np.round(d_signal, 0, d_signal)
                 d_signal = d_signal.astype(intdtype, copy=False)
 
                 if nanlocs.any():

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -544,7 +544,9 @@ class SignalMixin(object):
                         self.e_p_signal[ch],
                     )
                     np.add(
-                        e_p_signal[ch], self.baseline[ch], self.e_p_signal[ch]
+                        self.e_p_signal[ch],
+                        self.baseline[ch],
+                        self.e_p_signal[ch],
                     )
                     self.e_p_signal[ch] = self.e_p_signal[ch].astype(
                         intdtype, copy=False


### PR DESCRIPTION
When converting physical (floating-point) values to digital (integer) values, we generally want to round to the nearest integer, not truncate towards zero.

(Translating floating-point data to integers is *more complicated than you'd think*, but we should try to avoid creating new sources of errors.)

One example:
```
>>> p = wfdb.rdrecord('sample-data/v102s', physical=True)
>>> d = wfdb.rdrecord('sample-data/v102s', physical=False)
>>> p.adc() == d.d_signal
array([[ True,  True,  True,  True],
       [ True,  True, False,  True],
       [ True,  True,  True,  True],
       ...,
       [ True,  True,  True,  True],
       [ True,  True,  True,  True],
       [ True,  True,  True,  True]])
```
(we would of course expect these arrays to be equal.)

This fixes issue #418.

*edit: I am not good at copy and paste*
