### PR TITLE
FLAC output and assorted wrsamp improvements

### DIFF
--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -255,6 +255,23 @@ class TestRecord(unittest.TestCase):
         record_write = wfdb.rdrecord("flacformats", physical=False)
         assert record == record_write
 
+    def test_read_write_flac_multifrequency(self):
+        """
+        Format 516 with multiple signal files and variable samples per frame.
+        """
+        # Check that we can read a record and write it out again
+        record = wfdb.rdrecord(
+            "sample-data/mixedsignals",
+            physical=False,
+            smooth_frames=False,
+        )
+        record.wrsamp(expanded=True)
+
+        # Check that result matches the original
+        record = wfdb.rdrecord("sample-data/mixedsignals", smooth_frames=False)
+        record_write = wfdb.rdrecord("mixedsignals", smooth_frames=False)
+        assert record == record_write
+
     def test_read_flac_longduration(self):
         """
         Three signals multiplexed in a FLAC file, over 2**24 samples.
@@ -637,6 +654,10 @@ class TestRecord(unittest.TestCase):
             "flacformats.d1",
             "flacformats.d2",
             "flacformats.hea",
+            "mixedsignals.hea",
+            "mixedsignals_e.dat",
+            "mixedsignals_p.dat",
+            "mixedsignals_r.dat",
             "s0010_re.dat",
             "s0010_re.hea",
             "s0010_re.xyz",

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -219,7 +219,7 @@ class TestRecord(unittest.TestCase):
                             "Mismatch in %s" % name,
                         )
 
-    def test_read_flac(self):
+    def test_read_write_flac(self):
         """
         All FLAC formats, multiple signal files in one record.
 
@@ -249,6 +249,11 @@ class TestRecord(unittest.TestCase):
                         sig_target[sampfrom:sampto, n],
                         f"Mismatch in {name}",
                     )
+
+        # Test file writing
+        record.wrsamp()
+        record_write = wfdb.rdrecord("flacformats", physical=False)
+        assert record == record_write
 
     def test_read_flac_longduration(self):
         """
@@ -628,6 +633,10 @@ class TestRecord(unittest.TestCase):
             "100_3chan.hea",
             "a103l.hea",
             "a103l.mat",
+            "flacformats.d0",
+            "flacformats.d1",
+            "flacformats.d2",
+            "flacformats.hea",
             "s0010_re.dat",
             "s0010_re.hea",
             "s0010_re.xyz",

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -950,7 +950,7 @@ class SignalMixin(object):
                     dat_offsets[fn],
                     True,
                     [self.e_d_signal[ch] for ch in dat_channels[fn]],
-                    self.samps_per_frame,
+                    [self.samps_per_frame[ch] for ch in dat_channels[fn]],
                     write_dir=write_dir,
                 )
         else:

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -2303,9 +2303,13 @@ def wr_dat_file(
         # Create a copy to prevent overwrite
         d_signal = d_signal.copy()
 
-    # This n_sig is used for making list items.
-    # Does not necessarily represent number of signals (ie. for expanded=True)
-    n_sig = d_signal.shape[1]
+        # Non-expanded format always has 1 sample per frame
+        n_sig = d_signal.shape[1]
+        samps_per_frame = [1] * n_sig
+
+    # Total number of samples per frame (equal to number of signals if
+    # expanded=False, but may be greater for expanded=True)
+    tsamps_per_frame = d_signal.shape[1]
 
     if fmt == "80":
         # convert to 8 bit offset binary form
@@ -2363,8 +2367,8 @@ def wr_dat_file(
         # convert to 16 bit two's complement
         d_signal[d_signal < 0] = d_signal[d_signal < 0] + 65536
         # Split samples into separate bytes using binary masks
-        b1 = d_signal & [255] * n_sig
-        b2 = (d_signal & [65280] * n_sig) >> 8
+        b1 = d_signal & [255] * tsamps_per_frame
+        b2 = (d_signal & [65280] * tsamps_per_frame) >> 8
         # Interweave the bytes so that the same samples' bytes are consecutive
         b1 = b1.reshape((-1, 1))
         b2 = b2.reshape((-1, 1))
@@ -2376,9 +2380,9 @@ def wr_dat_file(
         # convert to 24 bit two's complement
         d_signal[d_signal < 0] = d_signal[d_signal < 0] + 16777216
         # Split samples into separate bytes using binary masks
-        b1 = d_signal & [255] * n_sig
-        b2 = (d_signal & [65280] * n_sig) >> 8
-        b3 = (d_signal & [16711680] * n_sig) >> 16
+        b1 = d_signal & [255] * tsamps_per_frame
+        b2 = (d_signal & [65280] * tsamps_per_frame) >> 8
+        b3 = (d_signal & [16711680] * tsamps_per_frame) >> 16
         # Interweave the bytes so that the same samples' bytes are consecutive
         b1 = b1.reshape((-1, 1))
         b2 = b2.reshape((-1, 1))
@@ -2392,10 +2396,10 @@ def wr_dat_file(
         # convert to 32 bit two's complement
         d_signal[d_signal < 0] = d_signal[d_signal < 0] + 4294967296
         # Split samples into separate bytes using binary masks
-        b1 = d_signal & [255] * n_sig
-        b2 = (d_signal & [65280] * n_sig) >> 8
-        b3 = (d_signal & [16711680] * n_sig) >> 16
-        b4 = (d_signal & [4278190080] * n_sig) >> 24
+        b1 = d_signal & [255] * tsamps_per_frame
+        b2 = (d_signal & [65280] * tsamps_per_frame) >> 8
+        b3 = (d_signal & [16711680] * tsamps_per_frame) >> 16
+        b4 = (d_signal & [4278190080] * tsamps_per_frame) >> 24
         # Interweave the bytes so that the same samples' bytes are consecutive
         b1 = b1.reshape((-1, 1))
         b2 = b2.reshape((-1, 1))

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -2288,7 +2288,14 @@ def wr_dat_file(
     # Combine list of arrays into single array
     if expanded:
         n_sig = len(e_d_signal)
-        sig_len = int(len(e_d_signal[0]) / samps_per_frame[0])
+        if len(samps_per_frame) != n_sig:
+            raise ValueError("mismatch between samps_per_frame and e_d_signal")
+
+        sig_len = len(e_d_signal[0]) // samps_per_frame[0]
+        for sig, spf in zip(e_d_signal, samps_per_frame):
+            if len(sig) != sig_len * spf:
+                raise ValueError("mismatch in lengths of expanded signals")
+
         # Effectively create MxN signal, with extra frame samples acting
         # like extra channels
         d_signal = np.zeros((sig_len, sum(samps_per_frame)), dtype="int64")

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -2266,16 +2266,15 @@ def wr_dat_file(
     fmt : str
         WFDB fmt of the dat file.
     d_signal : ndarray
-        The digital conversion of the signal. Either a 2d numpy
-        array or a list of 1d numpy arrays.
+        The digital conversion of the signal, as a 2d numpy array.
     byte_offset : int
         The byte offset of the dat file.
     expanded : bool, optional
         Whether to transform the `e_d_signal` attribute (True) or
         the `d_signal` attribute (False).
-    d_signal : ndarray, optional
-        The expanded digital conversion of the signal. Either a 2d numpy
-        array or a list of 1d numpy arrays.
+    e_d_signal : ndarray, optional
+        The expanded digital conversion of the signal, as a list of 1d
+        numpy arrays.
     samps_per_frame : list, optional
         The samples/frame for each signal of the dat file.
     write_dir : str, optional

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -954,8 +954,7 @@ class SignalMixin(object):
                     write_dir=write_dir,
                 )
         else:
-            # Create a copy to prevent overwrite
-            dsig = self.d_signal.copy()
+            dsig = self.d_signal
             for fn in file_names:
                 wr_dat_file(
                     fn,
@@ -2301,6 +2300,9 @@ def wr_dat_file(
             for framenum in range(spf):
                 d_signal[:, expand_ch] = e_d_signal[ch][framenum::spf]
                 expand_ch = expand_ch + 1
+    else:
+        # Create a copy to prevent overwrite
+        d_signal = d_signal.copy()
 
     # This n_sig is used for making list items.
     # Does not necessarily represent number of signals (ie. for expanded=True)

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -520,9 +520,15 @@ class BaseRecord(object):
                             "block_size values must be non-negative integers"
                         )
                 elif field == "sig_name":
-                    if re.search(r"\s", item[ch]):
+                    if item[ch][:1].isspace() or item[ch][-1:].isspace():
                         raise ValueError(
-                            "sig_name strings may not contain whitespaces."
+                            "sig_name strings may not begin or end with "
+                            "whitespace."
+                        )
+                    if re.search(r"[\x00-\x1f\x7f-\x9f]", item[ch]):
+                        raise ValueError(
+                            "sig_name strings may not contain "
+                            "control characters."
                         )
                     if len(set(item)) != len(item):
                         raise ValueError("sig_name strings must be unique.")


### PR DESCRIPTION
This is another mixed bag of changes to `wfdb.wrsamp` and `Record.wrsamp`.

The main goal here is to allow writing compressed (FLAC) signal files.

Just as with reading signal files, this requires rearranging the input data (`d_signal` or `e_d_signal`) into the format required by the soundfile package.  Just as with reading signal files, this is not done as efficiently as it could be (in fact, none of the formats in `wr_dat_file` are implemented as efficiently as they could be.)

It's worth noting that `soundfile` doesn't provide a way to set the compression level or other parameters.  Setting the compression level, at least, should be easy to implement if somebody wanted to.  The `libsndfile` default appears to be level 5 (the same default as `libwfdb` and the `flac` command-line tool.)

When writing a record in FLAC format, it may be necessary to use multiple signal files (either because there are more than 8 channels or there are multiple sampling frequencies.)  `wfdb.wrsamp` doesn't provide a way to set the signal file names (which is likely a good thing; we don't need to over-complicate this API.)  On the other hand, `wfdb.wrsamp` *does* accept a *list* of file formats, even though it will fail if you try to use different formats for one signal file.  So here I have extended it to generate multiple signal files (`record_1.dat`, `record_2.dat`, etc.) if the formats require it.

In order to test reading and writing the sample record "flacformats", it was also necessary to fix another long-standing issue (`check_field` rejecting signal names containing spaces.)

Additionally, `Record.wrsamp` was broken for the case of expanded (multi-frequency) format and multiple signal files.  `wr_dat_file` will now sanity-check its arguments to try to catch such issues.
