### PR TITLE
Set correct checksums and samps_per_frame in Record.wrsamp

### DIFF
--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -633,6 +633,22 @@ class TestRecord(unittest.TestCase):
 
         assert np.array_equal(sig_round, sig_target)
 
+    def test_write_smoothed(self):
+        """
+        Test writing a record after reading with smooth_frames
+        """
+        record = wfdb.rdrecord(
+            "sample-data/drive02",
+            physical=False,
+            smooth_frames=True,
+        )
+        record.wrsamp(write_dir=self.temp_path)
+        record2 = wfdb.rdrecord(
+            os.path.join(self.temp_path, "drive02"),
+            physical=False,
+        )
+        np.testing.assert_array_equal(record.d_signal, record2.d_signal)
+
     def test_to_dataframe(self):
         record = wfdb.rdrecord("sample-data/test01_00s")
         df = record.to_dataframe()

--- a/wfdb/io/_header.py
+++ b/wfdb/io/_header.py
@@ -278,7 +278,7 @@ class HeaderMixin(BaseHeaderMixin):
         for f in sfields:
             self.set_default(f)
 
-    def wrheader(self, write_dir=""):
+    def wrheader(self, write_dir="", expanded=True):
         """
         Write a WFDB header file. The signals are not used. Before
         writing:
@@ -290,6 +290,10 @@ class HeaderMixin(BaseHeaderMixin):
         ----------
         write_dir : str, optional
             The output directory in which the header is written.
+        expanded : bool, optional
+            Whether the header file should include `samps_per_frame` (this
+            should only be true if the signal files are written using
+            `expanded=True`).
 
         Returns
         -------
@@ -305,6 +309,8 @@ class HeaderMixin(BaseHeaderMixin):
         # sig_write_fields is a dictionary of
         # {field_name:required_channels}
         rec_write_fields, sig_write_fields = self.get_write_fields()
+        if not expanded:
+            sig_write_fields.pop("samps_per_frame", None)
 
         # Check the validity of individual fields used to write the header
         # Record specification fields (and comments)

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -142,7 +142,7 @@ class SignalMixin(object):
         # Get all the fields used to write the header
         # Assuming this method was called through wrsamp,
         # these will have already been checked in wrheader()
-        write_fields = self.get_write_fields()
+        _, _ = self.get_write_fields()
 
         if expanded:
             # Using list of arrays e_d_signal
@@ -152,8 +152,10 @@ class SignalMixin(object):
             self.check_field("d_signal")
 
         # Check the cohesion of the d_signal field against the other
-        # fields used to write the header
-        self.check_sig_cohesion(write_fields, expanded)
+        # fields used to write the header.  (Note that for historical
+        # reasons, this doesn't actually check any of the optional
+        # header fields.)
+        self.check_sig_cohesion([], expanded)
 
         # Write each of the specified dat files
         self.wr_dat_files(expanded=expanded, write_dir=write_dir)

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -194,10 +194,8 @@ class SignalMixin(object):
             for ch in range(self.n_sig):
                 if len(self.e_d_signal[ch]) != spf[ch] * self.sig_len:
                     raise ValueError(
-                        "Length of channel "
-                        + str(ch)
-                        + "does not match samps_per_frame["
-                        + str(ch + "]*sig_len")
+                        f"Length of channel {ch} does not match "
+                        f"samps_per_frame[{ch}]*sig_len"
                     )
 
             # For each channel (if any), make sure the digital format has no values out of bounds

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -924,7 +924,7 @@ class Record(BaseRecord, _header.HeaderMixin, _signal.SignalMixin):
         """
         # Perform field validity and cohesion checks, and write the
         # header file.
-        self.wrheader(write_dir=write_dir)
+        self.wrheader(write_dir=write_dir, expanded=expanded)
         if self.n_sig > 0:
             # Perform signal validity and cohesion checks, and write the
             # associated dat files.

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -922,6 +922,16 @@ class Record(BaseRecord, _header.HeaderMixin, _signal.SignalMixin):
         N/A
 
         """
+        # Update the checksum field (except for channels that did not have
+        # a checksum to begin with, or where the checksum was already
+        # valid.)
+        if self.checksum is not None:
+            checksums = self.calc_checksum(expanded=expanded)
+            for ch, old_val in enumerate(self.checksum):
+                if old_val is None or (checksums[ch] - old_val) % 65536 == 0:
+                    checksums[ch] = old_val
+            self.checksum = checksums
+
         # Perform field validity and cohesion checks, and write the
         # header file.
         self.wrheader(write_dir=write_dir, expanded=expanded)


### PR DESCRIPTION
There are a couple of ways to write a record using this package.  One is `wfdb.wrsamp`, the other is creating a `Record` object and calling the `wrsamp` method.

`Record.wrsamp` was, I think, meant to be more low-level and perhaps only intended for internal use of the package.  But for various reasons, applications may want or need to call this method directly.  So I think we need to support it, and make it more fool-proof; in particular, this method shouldn't generate *invalid* WFDB records even if the application supplies wrong parameters.

Here I address two of those parameters - `checksum` and `samps_per_frame`.

Typically, `checksum` is set by `wfdb.rdrecord`.  But naturally, the input data may have been *modified* (explicitly by the application, or implicitly e.g. by `smooth_frames`) between reading the record and writing it.  So when calling `Record.wrsamp`, we want to set this field to the actual checksums of the signals.  For backward compatibility and for applications that want to *edit an existing header file*, we leave the checksums alone if they're absent or if they're already correct.

(WFDB checksums are stored and written as an integer but only the low 16 bits are used.  So values of -1 and 65535 are equally correct.  Yes, this is kind of broken.)

`samps_per_frame` is only relevant when writing multi-frequency data.  If you are writing single-frequency signal files, then the header file must not claim there are multiple samples per frame.  Since the field is optional, we can simply drop it when `expanded` is false.

(If you are writing multi-frequency signal files, then `Record.wrsamp` does correctly verify that `samps_per_frame` is consistent with the dimensions of `e_d_signal`.)

Fixes issue #333.
