### PR TITLE
Correct example code for rdheader

### DIFF
--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -1825,8 +1825,7 @@ def rdheader(record_name, pn_dir=None, rd_segments=False):
 
     Examples
     --------
-    >>> ecg_record = wfdb.rdheader('sample-data/test01_00s', sampfrom=800,
-                                   channels = [1,3])
+    >>> ecg_record = wfdb.rdheader('100', pn_dir='mitdb')
 
     """
     dir_name, base_record_name = os.path.split(record_name)


### PR DESCRIPTION
Noticed that the example code for `wfdb.rdheader` seemed to be out of date - updated it to match the actual function signature.