### PR TITLE
Remove version caps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,18 +10,18 @@ documentation = "https://wfdb.readthedocs.io/"
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.7"
-numpy = "^1.10.1"
-scipy = "^1.0.0"
+python = ">=3.7"
+numpy = ">=1.10.1"
+scipy = ">=1.0.0"
 pandas = ">=1.3.0"
-SoundFile = ">=0.10.0, <0.12.0"
-matplotlib = "^3.2.2"
-requests = "^2.8.1"
-pytest = {version = "^7.1.1", optional = true}
-pytest-xdist = {version = "^2.5.0", optional = true}
-pylint = {version = "^2.13.7", optional = true}
-black = {version = "^22.3.0", optional = true}
-Sphinx = {version = "^4.5.0", optional = true}
+SoundFile = ">=0.10.0"
+matplotlib = ">=3.2.2"
+requests = ">=2.8.1"
+pytest = {version = ">=7.1.1", optional = true}
+pytest-xdist = {version = ">=2.5.0", optional = true}
+pylint = {version = ">=2.13.7", optional = true}
+black = {version = ">=22.3.0", optional = true}
+Sphinx = {version = ">=4.5.0", optional = true}
 
 [tool.poetry.extras]
 dev = ["pytest", "pytest-xdist", "pylint", "black", "Sphinx"]

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -63,7 +63,6 @@ class test_processing:
         assert sp.shape == (0,)
 
     def test_gqrs(self):
-
         record = wfdb.rdrecord(
             "sample-data/100",
             channels=[0],

--- a/wfdb/io/_header.py
+++ b/wfdb/io/_header.py
@@ -426,7 +426,6 @@ class HeaderMixin(BaseHeaderMixin):
         # Signal specification fields
         # Setting entire list default, not filling in blanks in lists.
         elif field in SIGNAL_SPECS.index:
-
             # Specific dynamic case
             if field == "file_name" and self.file_name is None:
                 self.file_name = self._auto_signal_file_names()
@@ -472,7 +471,6 @@ class HeaderMixin(BaseHeaderMixin):
         """
         # If there are no signal specification fields, there is nothing to check.
         if self.n_sig > 0:
-
             # The length of all signal specification fields must match n_sig
             # even if some of its elements are None.
             for f in sig_write_fields:

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -1985,7 +1985,6 @@ def _skew_sig(
 
     """
     if max(skew) > 0:
-
         # Expanded frame samples. List of arrays.
         if isinstance(sig, list):
             # Shift the channel samples

--- a/wfdb/io/annotation.py
+++ b/wfdb/io/annotation.py
@@ -156,7 +156,6 @@ class Annotation(object):
         custom_labels=None,
         contained_labels=None,
     ):
-
         self.record_name = record_name
         self.extension = extension
 
@@ -1180,7 +1179,6 @@ class Annotation(object):
 
         # Iterate across all fields one index at a time
         for i in range(len(sampdiff)):
-
             # Process the samp (difference) and sym items
             data_bytes.append(
                 field2bytes(
@@ -2152,7 +2150,6 @@ def proc_ann_bytes(filebytes, sampto):
     # - other pairs (if any)
     # The last byte pair of the file is 0 indicating eof.
     while bpi < filebytes.shape[0] - 1:
-
         # Get the sample and label_store fields of the current annotation
         sample_diff, current_label_store, bpi = proc_core_fields(filebytes, bpi)
         sample_total = sample_total + sample_diff
@@ -3018,7 +3015,6 @@ class AnnotationClass(object):
     """
 
     def __init__(self, extension, description, human_reviewed):
-
         self.extension = extension
         self.description = description
         self.human_reviewed = human_reviewed
@@ -3053,6 +3049,7 @@ ann_class_table.set_index(ann_class_table["extension"].values, inplace=True)
 ann_class_table = ann_class_table[
     ["extension", "description", "human_reviewed"]
 ]
+
 
 # Individual annotation labels
 class AnnotationLabel(object):

--- a/wfdb/io/convert/edf.py
+++ b/wfdb/io/convert/edf.py
@@ -126,7 +126,6 @@ def read_edf(
 
     """
     if pn_dir is not None:
-
         if "." not in pn_dir:
             dir_list = pn_dir.split("/")
             pn_dir = posixpath.join(
@@ -762,7 +761,6 @@ def wfdb_to_edf(
         output_filename = record_name_out + ".edf"
 
     with open(output_filename, "wb") as f:
-
         print(
             "Converting record {} to {} ({} mode)".format(
                 record_name, output_filename, "EDF+" if edf_plus else "EDF"

--- a/wfdb/io/convert/wav.py
+++ b/wfdb/io/convert/wav.py
@@ -225,7 +225,6 @@ def read_wav(record_name, pn_dir=None, delete_file=True, record_only=False):
         raise Exception("Name of the input file must end in .wav")
 
     if pn_dir is not None:
-
         if "." not in pn_dir:
             dir_list = pn_dir.split("/")
             pn_dir = posixpath.join(

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -813,7 +813,6 @@ class Record(BaseRecord, _header.HeaderMixin, _signal.SignalMixin):
         sig_name=None,
         comments=None,
     ):
-
         # Note the lack of the 'n_seg' field. Single segment records cannot
         # have this field. Even n_seg = 1 makes the header a multi-segment
         # header.
@@ -877,7 +876,6 @@ class Record(BaseRecord, _header.HeaderMixin, _signal.SignalMixin):
             return False
 
         for k in att1.keys():
-
             v1 = att1[k]
             v2 = att2[k]
 
@@ -894,7 +892,7 @@ class Record(BaseRecord, _header.HeaderMixin, _signal.SignalMixin):
                 and len(v1) == len(v2)
                 and all(isinstance(e, np.ndarray) for e in v1)
             ):
-                for (e1, e2) in zip(v1, v2):
+                for e1, e2 in zip(v1, v2):
                     np.testing.assert_array_equal(e1, e2)
             else:
                 if v1 != v2:
@@ -988,7 +986,6 @@ class Record(BaseRecord, _header.HeaderMixin, _signal.SignalMixin):
             # Checksum and init_value to be updated if present
             # unless the whole signal length was input
             if self.sig_len != self.d_signal.shape[0]:
-
                 if self.checksum is not None:
                     self.checksum = self.calc_checksum()
                 if self.init_value is not None:
@@ -1136,7 +1133,6 @@ class MultiRecord(BaseRecord, _header.MultiHeaderMixin):
         sig_name=None,
         sig_segments=None,
     ):
-
         super(MultiRecord, self).__init__(
             record_name=record_name,
             n_sig=n_sig,
@@ -1203,7 +1199,6 @@ class MultiRecord(BaseRecord, _header.MultiHeaderMixin):
             raise ValueError("Length of segments must match the 'n_seg' field")
 
         for seg_num, segment in enumerate(self.segments):
-
             # If segment 0 is a layout specification record, check that its file names are all == '~''
             if seg_num == 0 and self.seg_len[0] == 0:
                 for file_name in segment.file_name:

--- a/wfdb/processing/hr.py
+++ b/wfdb/processing/hr.py
@@ -162,7 +162,6 @@ def ann2rr(
     format=None,
     as_array=True,
 ):
-
     """
     Obtain RR interval series from ECG annotation files.
 

--- a/wfdb/processing/qrs.py
+++ b/wfdb/processing/qrs.py
@@ -323,7 +323,6 @@ class XQRS(object):
 
         # Found enough calibration beats to initialize parameters
         if len(qrs_inds) == n_calib_beats:
-
             if self.verbose:
                 print(
                     "Found %d beats during learning." % n_calib_beats


### PR DESCRIPTION
Currently, all versions are capped, because the caret `^` operator also introduces an upper bound. In this PR, I replaced `^` with `>=`, which continues to use the same lower bounds, but removes any upper bound.