### PR TITLE
Handle more than 8 compressed signals in wrsamp

### DIFF
--- a/wfdb/io/_header.py
+++ b/wfdb/io/_header.py
@@ -384,6 +384,7 @@ class HeaderMixin(BaseHeaderMixin):
                     num_groups += 1
                     channels_in_group = 0
             group_number.append(num_groups)
+            channels_in_group += 1
             prev_fmt = ch_fmt
             prev_spf = ch_spf
 


### PR DESCRIPTION
@alistairewj pointed out that there doesn't seem to be an easy way to write a compressed record with more than 8 channels.

It's supposed to be possible to do this:
```
import numpy, wfdb

wfdb.wrsamp('aaa', fs=1000, units=['mV'] * 12,
            sig_name=[str(i) for i in range(12)],
            p_signal=numpy.random.rand(100, 12),
            fmt=['516'] * 12)
```
but the logic I introduced in pull #420 is buggy and currently raises an error.
