### PR TITLE
Use int64 instead of int for ann2rr

### DIFF
--- a/wfdb/processing/hr.py
+++ b/wfdb/processing/hr.py
@@ -227,7 +227,7 @@ def ann2rr(
     elif format == "h":
         out_interval = time_interval / (60 * 60)
     else:
-        out_interval = np.around(time_interval * ann.fs).astype(np.int)
+        out_interval = np.around(time_interval * ann.fs).astype(np.int64)
 
     if as_array:
         return out_interval


### PR DESCRIPTION
This fixes issue #453 by using 64-bit integers on all platforms.  (64-bit integers are way overkill for storing RR intervals, but I think it's wise to keep it simple and use 64-bit integers for all types of sample intervals.)

This is a pretty simple fix, but looking at the code I also notice there are a couple of significant issues with this function:

- Unlike the ann2rr program, this function *only* considers the timestamps of the input annotations - it doesn't check whether they're QRS annotations or some other type of annotations (e.g. NOTE or RHYTHM).

- *Like* the ann2rr program, this function includes the interval between the first annotation and the start of the record.

As a result, when you look at Lucas's example in the docstring:
```
    >>> wfdb.ann2rr('sample-data/100', 'atr', as_array=False)
    >>> 18
    >>> 59
    >>> ...
    >>> 250
    >>> 257
```
the first two "RR intervals" listed here are bogus and misleading: the first is the interval between the start of the record and the first RHYTHM annotation, and the second is the interval between the RHYTHM annotation and the first NORMAL annotation.

All that is by way of saying, I'd like to add a test case for this function but I think it's kind of broken to begin with and probably its behavior should be better nailed down first.
