### PR TITLE
fixing rounding errors in to_dataframe in wfdb records

### DIFF
--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -1014,13 +1014,13 @@ class Record(BaseRecord, _header.HeaderMixin, _signal.SignalMixin):
             index = pd.date_range(
                 start=self.base_datetime,
                 periods=self.sig_len,
-                freq=pd.Timedelta(seconds=1 / self.fs),
+                end= self.get_absolute_time(self.sig_len - 1),
             )
         else:
             index = pd.timedelta_range(
                 start=pd.Timedelta(0),
                 periods=self.sig_len,
-                freq=pd.Timedelta(seconds=1 / self.fs),
+                end= self.get_absolute_time(self.sig_len - 1),
             )
 
         if self.p_signal is not None:


### PR DESCRIPTION
This pull request fixes issue #444. 

This PR refactors the index generation logic in the `to_dataframe` method in `BaseRecord class`

The current code uses the `freq` argument in the `pd.date_range` and `pd.timedelta_range` functions to generate the index for the DataFrame. However, using `end` argument improves accuracy of the time without being off by 0.287sec

```
>>>r = wfdb.rdrecord('81739927', pn_dir='mimic4wdb/0.1.0/waves/p100/p10014354/81739927')`
>>> str(r.base_datetime)
'2148-08-16 09:00:17.566000'
>>> r.to_dataframe()
                                I     II    III      V  aVR     Pleth      Resp
2148-08-16 09:00:17.566000000 NaN    NaN    NaN    NaN  NaN       NaN -0.751374
2148-08-16 09:00:17.582007043 NaN    NaN    NaN    NaN  NaN       NaN -0.751374
2148-08-16 09:00:17.598014086 NaN    NaN    NaN    NaN  NaN       NaN -0.751374
2148-08-16 09:00:17.614021129 NaN    NaN    NaN    NaN  NaN       NaN -0.751374
2148-08-16 09:00:17.630028172 NaN    NaN    NaN    NaN  NaN       NaN -0.751374
...                            ..    ...    ...    ...  ...       ...       ...
2148-08-17 14:37:22.320232945 NaN -0.220 -0.285 -0.025  NaN  0.404297  0.487477
2148-08-17 14:37:22.336239988 NaN -0.030  0.005  0.025  NaN  0.396484  0.530238
2148-08-17 14:37:22.352247031 NaN -0.065 -0.030 -0.015  NaN  0.386475  0.574832
2148-08-17 14:37:22.368254074 NaN -0.265 -0.255 -0.125  NaN  0.375977  0.621258
2148-08-17 14:37:22.384261117 NaN -0.550 -0.610 -0.355  NaN  0.366211  0.664020
[6661120 rows x 7 columns]
>>> str(r.get_absolute_time(6661119)
'2148-08-17 14:37:22.384920'
```
The get_absolute_time is correct to the nearest microsecond 14:37:22.384920 and the to_dataframe() is correct to the nearest nanosecond 14:37:22.384261117
Please review the PR at your convenience.