### PR TITLE
bug-fix: Numpy ValueError when cheking empty list equality

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/wfdb/io/annotation.py
+++ b/wfdb/io/annotation.py
@@ -940,10 +940,10 @@ class Annotation(object):
         core_bytes = self.calc_core_bytes()
 
         # Mark the end of the special annotation types if needed
-        if fs_bytes == [] and cl_bytes == []:
-            end_special_bytes = []
-        else:
+        if len(fs_bytes) or len(cl_bytes):
             end_special_bytes = [0, 236, 255, 255, 255, 255, 1, 0]
+        else:
+            end_special_bytes = []
 
         # Write the file
         with open(


### PR DESCRIPTION
Using the equality operator with an empty list will result in the following error.

ValueError: operands could not be broadcast together with shapes (28,) (0,)

Using len() and inverting the logic avoids this issue.