### PR TITLE
bug-fix: Pandas set indexing error

### DIFF
--- a/wfdb/io/annotation.py
+++ b/wfdb/io/annotation.py
@@ -1352,7 +1352,7 @@ class Annotation(object):
         else:
             raise Exception("No annotation labels contained in object")
 
-        contained_labels = label_map.loc[index_vals, :]
+        contained_labels = label_map.loc[list(index_vals), :]
 
         # Add the counts
         for i in range(len(counts[0])):


### PR DESCRIPTION
Current version of Pandas will throw the following error when indexing using a set.

TypeError: Passing a set as an indexer is not supported. Use a list instead.