### PR TITLE
Updated checksum Calculation function: calc_checksum

### DIFF
--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -909,8 +909,25 @@ class SignalMixin(object):
         if expanded:
             cs = [int(np.sum(s) % 65536) for s in self.e_d_signal]
         else:
-            cs = np.sum(self.d_signal, 0) % 65536
-            cs = [int(c) for c in cs]
+            cs = np.sum(self.d_signal, 0)
+            
+            checksum = []
+            for c in cs:
+                M = c/32768
+                if M < 0:
+                    c = c % -32768
+                    if(~c and abs(M) < 1):
+                        c = -32768
+                    elif(math.ceil(M)%2):
+                        c = 32768 + c
+                
+                else:
+                    c = c % 32768
+                    if(math.floor(M)%2):
+                        c = -32768 + c
+                checksum.append(c)
+            
+            cs = [int(c) for c in checksum]
         return cs
 
     def wr_dat_files(self, expanded=False, write_dir=""):


### PR DESCRIPTION
The current checksum logic in the wfdb-python library does not take into consideration the sign of the sum of the values. The function computes the sum and performs the mod operation without considering the correct range of the output and overflow. The resulting checksum values in the header file do not match with the corresponding values from the header file generated with MATLAB.

With the implemented logic here, the sum is first calculated and based on the sign of the value correct modulation operation is performed. Line 917-922 is for sum < 0 and line 924-927 is for sum >=0. The logic also accounts for the boundary condition (Line 919). The logic is line with MATLAB implementation of checksum calculation (https://github.com/ikarosilva/wfdb-app-toolbox/blob/6e81e0d4e7e275418bc13def7c29d6a4464a519b/mcode/mat2wfdb.m#L453).