### PR TITLE
fix for MIT-LCP/wfdb-python/issues/452

### DIFF
--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -3049,7 +3049,7 @@ def dl_database(
     for rec in record_list:
         print("Generating record list for: " + rec)
         # May be pointing to directory
-        if rec.endswith(os.sep):
+        if rec.endswith("/"):
             nested_records += [
                 posixpath.join(rec, sr)
                 for sr in download.get_record_list(posixpath.join(db_dir, rec))


### PR DESCRIPTION
Fix for MIT-LCP/wfdb-python/issues/452

Using os.sep on Windows fails here because we are specifically searching for "/" as a separator