### PR TITLE
Fix NaN handling in Record.adc, and other fixes

### DIFF
--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -1053,19 +1053,20 @@ class TestSignal(unittest.TestCase):
         adc_gain = [1.0, 1234.567, 765.4321]
         baseline = [10, 20, -30]
         d_signal = np.repeat(np.arange(-100, 100), 3).reshape(-1, 3)
+        d_signal[5:10, :] = [-32768, -2048, -128]
         e_d_signal = list(d_signal.transpose())
-        fmt = ["16", "16", "16"]
+        fmt = ["16", "212", "80"]
 
         # Test adding or subtracting a small offset (0.01 ADU) to check
         # that we correctly round to the nearest integer
         for offset in (0, -0.01, 0.01):
             p_signal = (d_signal + offset - baseline) / adc_gain
+            p_signal[5:10, :] = np.nan
             e_p_signal = list(p_signal.transpose())
 
             # Test converting p_signal to d_signal
 
             record = wfdb.Record(
-                n_sig=n_sig,
                 p_signal=p_signal.copy(),
                 adc_gain=adc_gain,
                 baseline=baseline,
@@ -1081,7 +1082,6 @@ class TestSignal(unittest.TestCase):
             # Test converting e_p_signal to e_d_signal
 
             record = wfdb.Record(
-                n_sig=n_sig,
                 e_p_signal=[s.copy() for s in e_p_signal],
                 adc_gain=adc_gain,
                 baseline=baseline,
@@ -1108,7 +1108,7 @@ class TestSignal(unittest.TestCase):
                 p_signal=p_signal,
                 adc_gain=adc_gain,
                 baseline=baseline,
-                fmt=["16", "16", "16"],
+                fmt=fmt,
                 write_dir=self.temp_path,
             )
             record = wfdb.rdrecord(

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -581,13 +581,12 @@ class SignalMixin(object):
                     d_signal.append(ch_d_signal)
 
             else:
-                nanlocs = np.isnan(self.p_signal)
-                # Cannot cast dtype to int now because gain is float.
-                d_signal = self.p_signal.copy()
-                np.multiply(d_signal, self.adc_gain, d_signal)
-                np.add(d_signal, self.baseline, d_signal)
-                np.round(d_signal, 0, d_signal)
-                d_signal = d_signal.astype(intdtype, copy=False)
+                p_signal = self.p_signal.copy()
+                nanlocs = np.isnan(p_signal)
+                np.multiply(p_signal, self.adc_gain, p_signal)
+                np.add(p_signal, self.baseline, p_signal)
+                np.round(p_signal, 0, p_signal)
+                d_signal = p_signal.astype(intdtype, copy=False)
 
                 if nanlocs.any():
                     for ch in range(d_signal.shape[1]):

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -561,9 +561,9 @@ class SignalMixin(object):
         # Do inplace conversion and set relevant variables.
         if inplace:
             if expanded:
-                for ch in range(self.n_sig):
+                for ch, ch_p_signal in enumerate(self.e_p_signal):
                     ch_d_signal = adc_inplace_1d(
-                        self.e_p_signal[ch],
+                        ch_p_signal,
                         self.adc_gain[ch],
                         self.baseline[ch],
                         d_nans[ch],
@@ -579,9 +579,9 @@ class SignalMixin(object):
         else:
             if expanded:
                 d_signal = []
-                for ch in range(self.n_sig):
+                for ch, ch_p_signal in enumerate(self.e_p_signal):
                     ch_d_signal = adc_inplace_1d(
-                        self.e_p_signal[ch].copy(),
+                        ch_p_signal.copy(),
                         self.adc_gain[ch],
                         self.baseline[ch],
                         d_nans[ch],

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -539,8 +539,8 @@ class SignalMixin(object):
             np.multiply(ch_p_signal, adc_gain, ch_p_signal)
             np.add(ch_p_signal, baseline, ch_p_signal)
             np.round(ch_p_signal, 0, ch_p_signal)
+            ch_p_signal[ch_nanlocs] = d_nan
             ch_d_signal = ch_p_signal.astype(intdtype, copy=False)
-            ch_d_signal[ch_nanlocs] = d_nan
             return ch_d_signal
 
         # Convert a 2D physical signal array to digital.  Note that the
@@ -550,12 +550,11 @@ class SignalMixin(object):
             np.multiply(p_signal, self.adc_gain, p_signal)
             np.add(p_signal, self.baseline, p_signal)
             np.round(p_signal, 0, p_signal)
-            d_signal = p_signal.astype(intdtype, copy=False)
-
             if nanlocs.any():
-                for ch in range(d_signal.shape[1]):
+                for ch in range(p_signal.shape[1]):
                     if nanlocs[:, ch].any():
-                        d_signal[nanlocs[:, ch], ch] = d_nans[ch]
+                        p_signal[nanlocs[:, ch], ch] = d_nans[ch]
+            d_signal = p_signal.astype(intdtype, copy=False)
             return d_signal
 
         # Do inplace conversion and set relevant variables.

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -551,23 +551,14 @@ class SignalMixin(object):
         if inplace:
             if expanded:
                 for ch in range(self.n_sig):
-                    # NAN locations for the channel
-                    ch_nanlocs = np.isnan(self.e_p_signal[ch])
-                    np.multiply(
-                        self.e_p_signal[ch],
-                        self.adc_gain[ch],
-                        self.e_p_signal[ch],
-                    )
-                    np.add(
-                        self.e_p_signal[ch],
-                        self.baseline[ch],
-                        self.e_p_signal[ch],
-                    )
-                    np.round(self.e_p_signal[ch], 0, self.e_p_signal[ch])
-                    self.e_p_signal[ch] = self.e_p_signal[ch].astype(
-                        intdtype, copy=False
-                    )
-                    self.e_p_signal[ch][ch_nanlocs] = d_nans[ch]
+                    ch_p_signal = self.e_p_signal[ch]
+                    ch_nanlocs = np.isnan(ch_p_signal)
+                    np.multiply(ch_p_signal, self.adc_gain[ch], ch_p_signal)
+                    np.add(ch_p_signal, self.baseline[ch], ch_p_signal)
+                    np.round(ch_p_signal, 0, ch_p_signal)
+                    ch_d_signal = ch_p_signal.astype(intdtype, copy=False)
+                    ch_d_signal[ch_nanlocs] = d_nans[ch]
+                    self.e_p_signal[ch] = ch_d_signal
                 self.e_d_signal = self.e_p_signal
                 self.e_p_signal = None
             else:

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -570,13 +570,12 @@ class SignalMixin(object):
             if expanded:
                 d_signal = []
                 for ch in range(self.n_sig):
-                    # NAN locations for the channel
-                    ch_nanlocs = np.isnan(self.e_p_signal[ch])
-                    ch_d_signal = self.e_p_signal[ch].copy()
-                    np.multiply(ch_d_signal, self.adc_gain[ch], ch_d_signal)
-                    np.add(ch_d_signal, self.baseline[ch], ch_d_signal)
-                    np.round(ch_d_signal, 0, ch_d_signal)
-                    ch_d_signal = ch_d_signal.astype(intdtype, copy=False)
+                    ch_p_signal = self.e_p_signal[ch].copy()
+                    ch_nanlocs = np.isnan(ch_p_signal)
+                    np.multiply(ch_p_signal, self.adc_gain[ch], ch_p_signal)
+                    np.add(ch_p_signal, self.baseline[ch], ch_p_signal)
+                    np.round(ch_p_signal, 0, ch_p_signal)
+                    ch_d_signal = ch_p_signal.astype(intdtype, copy=False)
                     ch_d_signal[ch_nanlocs] = d_nans[ch]
                     d_signal.append(ch_d_signal)
 

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -562,6 +562,12 @@ class SignalMixin(object):
                 np.add(p_signal, self.baseline, p_signal)
                 np.round(p_signal, 0, p_signal)
                 d_signal = p_signal.astype(intdtype, copy=False)
+
+                if nanlocs.any():
+                    for ch in range(d_signal.shape[1]):
+                        if nanlocs[:, ch].any():
+                            d_signal[nanlocs[:, ch], ch] = d_nans[ch]
+
                 self.d_signal = d_signal
                 self.p_signal = None
 

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -577,7 +577,7 @@ class SignalMixin(object):
         # Return the variable
         else:
             if expanded:
-                d_signal = []
+                e_d_signal = []
                 for ch, ch_p_signal in enumerate(self.e_p_signal):
                     ch_d_signal = adc_inplace_1d(
                         ch_p_signal.copy(),
@@ -585,12 +585,11 @@ class SignalMixin(object):
                         self.baseline[ch],
                         d_nans[ch],
                     )
-                    d_signal.append(ch_d_signal)
+                    e_d_signal.append(ch_d_signal)
+                return e_d_signal
 
             else:
-                d_signal = adc_inplace_2d(self.p_signal.copy())
-
-            return d_signal
+                return adc_inplace_2d(self.p_signal.copy())
 
     def dac(self, expanded=False, return_res=64, inplace=False):
         """

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -539,7 +539,7 @@ class SignalMixin(object):
             np.multiply(ch_p_signal, adc_gain, ch_p_signal)
             np.add(ch_p_signal, baseline, ch_p_signal)
             np.round(ch_p_signal, 0, ch_p_signal)
-            ch_p_signal[ch_nanlocs] = d_nan
+            np.copyto(ch_p_signal, d_nan, where=ch_nanlocs)
             ch_d_signal = ch_p_signal.astype(intdtype, copy=False)
             return ch_d_signal
 
@@ -550,10 +550,7 @@ class SignalMixin(object):
             np.multiply(p_signal, self.adc_gain, p_signal)
             np.add(p_signal, self.baseline, p_signal)
             np.round(p_signal, 0, p_signal)
-            if nanlocs.any():
-                for ch in range(p_signal.shape[1]):
-                    if nanlocs[:, ch].any():
-                        p_signal[nanlocs[:, ch], ch] = d_nans[ch]
+            np.copyto(p_signal, d_nans, where=nanlocs)
             d_signal = p_signal.astype(intdtype, copy=False)
             return d_signal
 

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -556,12 +556,13 @@ class SignalMixin(object):
                 self.e_d_signal = self.e_p_signal
                 self.e_p_signal = None
             else:
-                nanlocs = np.isnan(self.p_signal)
-                np.multiply(self.p_signal, self.adc_gain, self.p_signal)
-                np.add(self.p_signal, self.baseline, self.p_signal)
-                np.round(self.p_signal, 0, self.p_signal)
-                self.p_signal = self.p_signal.astype(intdtype, copy=False)
-                self.d_signal = self.p_signal
+                p_signal = self.p_signal
+                nanlocs = np.isnan(p_signal)
+                np.multiply(p_signal, self.adc_gain, p_signal)
+                np.add(p_signal, self.baseline, p_signal)
+                np.round(p_signal, 0, p_signal)
+                d_signal = p_signal.astype(intdtype, copy=False)
+                self.d_signal = d_signal
                 self.p_signal = None
 
         # Return the variable


### PR DESCRIPTION
Fix several bugs in `Record.adc`:

1. Previously, the function would try to convert all samples to integers and then, for any samples that were NaN, replace the corresponding elements with the appropriate sentinel value.  Even though this was probably safe in most cases, casting NaN to an integer is implementation-defined behavior, and raises a warning by default (issue #480).

2. NaN just plain wasn't handled for the `inplace=True, expanded=False` case.  (Currently, we don't use `inplace=True` anywhere internally; although it saves a bit of memory, it's destructive and so it's probably wise for high-level functions like `wrsamp` to avoid it.)

3. The `expanded=True` case relied on `self.n_sig` (in contrast to `expanded=False`, which operates based on the dimensions of `p_signal`.)  This meant it would fail if the caller didn't explicitly set `n_sig`, which was an annoying inconsistency.

Also, tidy up duplicated code and make things a little more efficient.

A side note: I don't think the `inplace=True` mode is particularly great to have.  It conflates two things (modifying the Record object attributes, which many applications want; and modifying the array contents, which you may think you want until you realize it subtly breaks something.)  It does save some memory, but not as much as you'd hope.  (That `copy=False` is pretty much a lie.)  And of course I don't like functions whose return type is dependent on their arguments.  So I would definitely put `inplace` on the chopping block for 5.0.0.  Still, I think the updated code here isn't too terribly ugly.

This set of changes is the first step to making `wfdb.wrsamp` work for multi-frequency (issue #336).  Next is to fix `Record.calc_adc_params`, then `Record.set_d_features`.
