### PR TITLE
Set upper bound on Numpy version (numpy = ">=1.10.1,<2.0.0"). Ref #493.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.7"
-numpy = ">=1.10.1"
+numpy = ">=1.10.1,<2.0.0"
 scipy = ">=1.0.0"
 pandas = ">=1.3.0"
 SoundFile = ">=0.10.0"


### PR DESCRIPTION
As discussed in #493, numpy v2.0.0 introduces a breaking change for WFDB: https://numpy.org/devdocs/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion. 

This pull request sets an upper bound on the numpy version as a temporary fix (`numpy = ">=1.10.1,<2.0.0"`).