### PR TITLE
Update actions to use actions/checkout@v3 and actions/setup-python@v4.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,9 +19,9 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -69,7 +69,7 @@ jobs:
   build-documentation:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
The "[run tests](https://github.com/MIT-LCP/wfdb-python/blob/main/.github/workflows/run-tests.yml)" GitHub workflow is raising [several warnings](https://github.com/MIT-LCP/wfdb-python/actions/runs/9783079800) about deprecated actions:

e.g.

> `[build (ubuntu-latest, 3.9)](https://github.com/MIT-LCP/wfdb-python/actions/runs/9783079800/job/27011340622)
The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/checkout@v2, actions/setup-python@v2. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/[build (ubuntu-latest, 3.9)](https://github.com/MIT-LCP/wfdb-python/actions/runs/9783079800/job/27011340622)
The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/checkout@v2, actions/setup-python@v2. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/`

This pull request updates the actions to the latest versions:

- actions/checkout@v2 -> actions/checkout@v3
- actions/setup-python@v2 -> actions/setup-python@v4

Note there is one outdated action that will need addressing at some point. As of today, the issue does not appear to have been addressed: https://github.com/actions/checkout/issues/334

```
      # Note: "actions/checkout@v2" requires libstdc++6:amd64 to be
      # installed in the container.  To keep things simple, use
      # "actions/checkout@v1" instead.
      # https://github.com/actions/checkout/issues/334
```