### PR TITLE
Fix: Indent code to ensure 'j' is within for-loop in GQRS algorithm

### DIFF
--- a/wfdb/processing/qrs.py
+++ b/wfdb/processing/qrs.py
@@ -1230,20 +1230,20 @@ class GQRS(object):
                     smtpj = self.at(smt + j)
                     smtlj = self.at(smt - j)
                     v += int(smtpj + smtlj)
-                self.smv_put(
-                    smt,
-                    (v << 1)
-                    + self.at(smt + j + 1)
-                    + self.at(smt - j - 1)
-                    - self.adc_zero * (smdt << 2),
-                )
+                    self.smv_put(
+                        smt,
+                        (v << 1)
+                        + self.at(smt + j + 1)
+                        + self.at(smt - j - 1)
+                        - self.adc_zero * (smdt << 2),
+                    )
 
-                self.SIG_SMOOTH.append(
-                    (v << 1)
-                    + self.at(smt + j + 1)
-                    + self.at(smt - j - 1)
-                    - self.adc_zero * (smdt << 2)
-                )
+                    self.SIG_SMOOTH.append(
+                        (v << 1)
+                        + self.at(smt + j + 1)
+                        + self.at(smt - j - 1)
+                        - self.adc_zero * (smdt << 2)
+                    )
         self.c.smt = smt
 
         return self.smv_at(at_t)


### PR DESCRIPTION
As discussed in https://github.com/MIT-LCP/wfdb-python/pull/489:

> "The variable j was not properly scoped within the for-loop in the sm method, leading to an UnboundLocalError when j was accessed outside the loop."

https://github.com/MIT-LCP/wfdb-python/pull/489 needs rebasing on the main branch to allow tests to run.

This pull request is just a cherry-pick of the commit in https://github.com/MIT-LCP/wfdb-python/pull/489, on top of the current version of main (I can't push to the other branch directly, because its on a forked repo).

