### PR TITLE
Fix warnings

### DIFF
--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -33,7 +33,8 @@ class TestAnnotation(unittest.TestCase):
         # no null to detect in the output text file of rdann.
 
         # Target data from WFDB software package
-        lines = tuple(open("tests/target-output/ann-1", "r"))
+        with open("tests/target-output/ann-1", "r") as f:
+            lines = tuple(f)
         nannot = len(lines)
 
         target_time = [None] * nannot
@@ -108,7 +109,8 @@ class TestAnnotation(unittest.TestCase):
         annotation = wfdb.rdann("sample-data/12726", "anI")
 
         # Target data from WFDB software package
-        lines = tuple(open("tests/target-output/ann-2", "r"))
+        with open("tests/target-output/ann-2", "r") as f:
+            lines = tuple(f)
         nannot = len(lines)
 
         target_time = [None] * nannot
@@ -181,7 +183,8 @@ class TestAnnotation(unittest.TestCase):
         annotation = wfdb.rdann("sample-data/1003", "atr")
 
         # Target data from WFDB software package
-        lines = tuple(open("tests/target-output/ann-3", "r"))
+        with open("tests/target-output/ann-3", "r") as f:
+            lines = tuple(f)
         nannot = len(lines)
 
         target_time = [None] * nannot

--- a/wfdb/io/convert/edf.py
+++ b/wfdb/io/convert/edf.py
@@ -438,6 +438,8 @@ def read_edf(
         int(np.sum(v) % 65536) for v in np.transpose(sig_data)
     ]  # not all values correct?
 
+    edf_file.close()
+
     record = Record(
         record_name=record_name_out,
         n_sig=n_sig,

--- a/wfdb/io/download.py
+++ b/wfdb/io/download.py
@@ -343,7 +343,7 @@ def get_annotators(db_dir, annotators):
             annotators = ann_list
         else:
             # In case they didn't input a list
-            if type(annotators) == str:
+            if type(annotators) is str:
                 annotators = [annotators]
             # user input ones. Check validity.
             for a in annotators:

--- a/wfdb/io/download.py
+++ b/wfdb/io/download.py
@@ -541,8 +541,6 @@ def dl_files(db, dl_dir, files, keep_subdirs=True, overwrite=False):
     print("Downloading files...")
     # Create multiple processes to download files.
     # Limit to 2 connections to avoid overloading the server
-    pool = multiprocessing.dummy.Pool(processes=2)
-    pool.map(dl_pn_file, dl_inputs)
+    with multiprocessing.dummy.Pool(processes=2) as pool:
+        pool.map(dl_pn_file, dl_inputs)
     print("Finished downloading files")
-
-    return

--- a/wfdb/io/download.py
+++ b/wfdb/io/download.py
@@ -143,7 +143,7 @@ def _stream_dat(file_name, pn_dir, byte_count, start_byte, dtype):
         content = f.read(byte_count)
 
     # Convert to numpy array
-    sig_data = np.fromstring(content, dtype=dtype)
+    sig_data = np.frombuffer(content, dtype=dtype)
 
     return sig_data
 
@@ -173,7 +173,7 @@ def _stream_annotation(file_name, pn_dir):
         content = f.read()
 
     # Convert to numpy array
-    ann_data = np.fromstring(content, dtype=np.dtype("<u1"))
+    ann_data = np.frombuffer(content, dtype=np.dtype("<u1"))
 
     return ann_data
 

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -3117,8 +3117,6 @@ def dl_database(
     print("Downloading files...")
     # Create multiple processes to download files.
     # Limit to 2 connections to avoid overloading the server
-    pool = multiprocessing.dummy.Pool(processes=2)
-    pool.map(download.dl_pn_file, dl_inputs)
+    with multiprocessing.dummy.Pool(processes=2) as pool:
+        pool.map(download.dl_pn_file, dl_inputs)
     print("Finished downloading files")
-
-    return


### PR DESCRIPTION
I've fixed a few warnings related to

- deprecated functions
- unclosed files
- unclosed multiprocessing pool

Now all tests pass without warnings (and errors of course).