### PR TITLE
Use uv

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,18 +24,17 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip poetry
-          pip install ".[dev]"
+          uv pip install ".[dev]"
       - name: Install libsndfile
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get install -y libsndfile1
       - name: Run tests
         run: pytest
-      - name: Validate poetry file
-        run: poetry check
       - name: Check source code format
         run: black --check --diff .
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run tests
         run: uv run --extra dev pytest
       - name: Check source code format
-        run: black --check --diff .
+        run: uv run --extra dev black --check --diff .
 
   test-deb10-i386:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,22 +19,17 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install uv
+      - uses: actions/checkout@v4
+      - name: Setup uv
         uses: astral-sh/setup-uv@v3
-      - name: Install dependencies
-        run: |
-          uv pip install --system ".[dev]"
+      - name: Install Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
       - name: Install libsndfile
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get install -y libsndfile1
       - name: Run tests
-        run: pytest
+        run: uv run --extra dev pytest
       - name: Check source code format
         run: black --check --diff .
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,7 +28,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
       - name: Install dependencies
         run: |
-          uv pip install ".[dev]"
+          uv pip install --system ".[dev]"
       - name: Install libsndfile
         if: startsWith(matrix.os, 'ubuntu')
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,3 @@ target/
 
 # pyenv
 .python-version
-
-# Poetry
-poetry.lock

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -26,7 +26,7 @@ uv add <somepackage> --optional <somegroup>
 
 ## Creating Distributions
 
-Make sure the versions in [version.py](./wfdb/version.py) and [pyproject.toml](./pyproject.toml) are updated and kept in sync.
+Make sure to update the version in [version.py](./wfdb/version.py) accordingly.
 
 It may be useful to publish to testpypi and preview the changes before publishing to PyPi. However, the project dependencies likely will not be available when trying to install from there.
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -16,16 +16,13 @@ black .
 
 ## Package and Dependency Management
 
-This project uses [poetry](https://python-poetry.org/docs/) for package management and distribution.
+This project uses [uv](https://docs.astral.sh/uv/) for package management and distribution.
 
-Development dependencies are specified as optional dependencies, and then added to the "dev" extra group in the [pyproject.toml](./pyproject.toml) file.
+Development dependencies are specified as optional dependencies, at least for now and until [development dependencies](https://docs.astral.sh/uv/concepts/dependencies/#development-dependencies) become more widely used.
 
 ```sh
-# Do NOT use: poetry add <somepackage> --dev
-poetry add --optional <somepackage>
+uv add <somepackage> --optional <somegroup>
 ```
-
-The `[tool.poetry.dev-dependencies]` attribute is NOT used because of a [limitation](https://github.com/python-poetry/poetry/issues/3514) that prevents these dependencies from being pip installable. Therefore, dev dependencies are not installed when purely running `poetry install`, and the `--no-dev` flag has no meaning in this project.
 
 ## Creating Distributions
 
@@ -47,10 +44,10 @@ poetry config pypi-token.test-pypi <my-testpypi-token>
 To build and upload a new distribution:
 
 ```sh
-poetry build
+uv build
 
-poetry publish -r test-pypi
-poetry publish
+uv publish --publish-url https://test.pypi.org/legacy/
+uv publish
 ```
 
 ## Creating Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "The WFDB Python package: tools for reading, writing, and processi
 authors = [{name = "The Laboratory for Computational Physiology", email = "contact@physionet.org"}]
 license = {text = "MIT License"}
 readme = "README.md"
-requires-python = ">= 3.7.1"
+requires-python = ">= 3.8"
 dependencies = [
     "numpy >= 1.10.1, < 2.0.0",
     "scipy >= 1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,4 +41,6 @@ target-version = ['py37']
 exclude = [
     "/tests",
     "/sample-data",
+    "/demo-img.png",
+    "/demo.ipynb",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,9 @@ documentation = "https://wfdb.readthedocs.io/"
 [tool.black]
 line-length = 80
 target-version = ['py37']
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "/tests",
+    "/sample-data",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,37 +1,38 @@
-[tool.poetry]
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
 name = "wfdb"
 version = "4.1.2"
 description = "The WFDB Python package: tools for reading, writing, and processing physiologic signals and annotations."
-authors = ["The Laboratory for Computational Physiology <contact@physionet.org>"]
+authors = [{name = "The Laboratory for Computational Physiology", email = "contact@physionet.org"}]
+license = {text = "MIT License"}
 readme = "README.md"
+requires-python = ">= 3.7"
+dependencies = [
+    "numpy >= 1.10.1, < 2.0.0",
+    "scipy >= 1.0.0",
+    "pandas >= 1.3.0",
+    "soundfile >= 0.10.0",
+    "matplotlib >= 3.2.2",
+    "requests >= 2.8.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest >= 7.1.1",
+    "pytest-xdist >= 2.5.0",
+    "pylint >= 2.13.7",
+    "black >= 22.3.0",
+    "sphinx >= 4.5.0",
+]
+
+[project.urls]
 homepage = "https://github.com/MIT-LCP/wfdb-python/"
 repository = "https://github.com/MIT-LCP/wfdb-python/"
 documentation = "https://wfdb.readthedocs.io/"
-license = "MIT"
-
-[tool.poetry.dependencies]
-python = ">=3.7"
-numpy = ">=1.10.1,<2.0.0"
-scipy = ">=1.0.0"
-pandas = ">=1.3.0"
-SoundFile = ">=0.10.0"
-matplotlib = ">=3.2.2"
-requests = ">=2.8.1"
-pytest = {version = ">=7.1.1", optional = true}
-pytest-xdist = {version = ">=2.5.0", optional = true}
-pylint = {version = ">=2.13.7", optional = true}
-black = {version = ">=22.3.0", optional = true}
-Sphinx = {version = ">=4.5.0", optional = true}
-
-[tool.poetry.extras]
-dev = ["pytest", "pytest-xdist", "pylint", "black", "Sphinx"]
-
-# Do NOT use [tool.poetry.dev-dependencies]. See: https://github.com/python-poetry/poetry/issues/3514
 
 [tool.black]
 line-length = 80
 target-version = ['py37']
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wfdb"
-version = "4.1.2"
 description = "The WFDB Python package: tools for reading, writing, and processing physiologic signals and annotations."
 authors = [{name = "The Laboratory for Computational Physiology", email = "contact@physionet.org"}]
 license = {text = "MIT License"}
@@ -18,6 +17,7 @@ dependencies = [
     "matplotlib >= 3.2.2",
     "requests >= 2.8.1",
 ]
+dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
@@ -44,3 +44,6 @@ exclude = [
     "/demo-img.png",
     "/demo.ipynb",
 ]
+
+[tool.hatch.version]
+path = "wfdb/version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "The WFDB Python package: tools for reading, writing, and processi
 authors = [{name = "The Laboratory for Computational Physiology", email = "contact@physionet.org"}]
 license = {text = "MIT License"}
 readme = "README.md"
-requires-python = ">= 3.7"
+requires-python = ">= 3.7.1"
 dependencies = [
     "numpy >= 1.10.1, < 2.0.0",
     "scipy >= 1.0.0",


### PR DESCRIPTION
Fixes #501.

To do:

- [ ] Adapt workflow to setup access to PyPI (see https://docs.astral.sh/uv/guides/publish/#publishing-a-package)
- [ ] Optimize tests (currently, I'm using `uv pip ...`, but I think this should be replaced with `uv run ...`
- [ ] Bump any package versions and/or Python?
- [ ] Use Ruff instead of Black?