### PR TITLE
Change in type promotion. Fixes to annotation.py

### DIFF
--- a/wfdb/io/annotation.py
+++ b/wfdb/io/annotation.py
@@ -2219,7 +2219,7 @@ def proc_core_fields(filebytes, bpi):
 
     # The current byte pair will contain either the actual d_sample + annotation store value,
     # or 0 + SKIP.
-    while filebytes[bpi, 1] >> 2 == 59:
+    while int(filebytes[bpi, 1]) >> 2 == 59:
         # 4 bytes storing dt
         skip_diff = (
             (int(filebytes[bpi + 1, 0]) << 16)
@@ -2237,7 +2237,9 @@ def proc_core_fields(filebytes, bpi):
 
     # Not a skip - it is the actual sample number + annotation type store value
     label_store = filebytes[bpi, 1] >> 2
-    sample_diff += int(filebytes[bpi, 0] + 256 * (filebytes[bpi, 1] & 3))
+    sample_diff += np.int64(filebytes[bpi, 0]) + 256 * np.int64(
+        filebytes[bpi, 1] & 3
+    )
     bpi = bpi + 1
 
     return sample_diff, label_store, bpi

--- a/wfdb/io/annotation.py
+++ b/wfdb/io/annotation.py
@@ -2162,7 +2162,7 @@ def proc_ann_bytes(filebytes, sampto):
         update = {"subtype": True, "chan": True, "num": True, "aux_note": True}
         # Get the next label store value - it may indicate additional
         # fields for this annotation, or the values of the next annotation.
-        current_label_store = filebytes[bpi, 1] >> 2
+        current_label_store = int(filebytes[bpi, 1]) >> 2
 
         while current_label_store > 59:
             subtype, chan, num, aux_note, update, bpi = proc_extra_field(
@@ -2176,7 +2176,7 @@ def proc_ann_bytes(filebytes, sampto):
                 update,
             )
 
-            current_label_store = filebytes[bpi, 1] >> 2
+            current_label_store = int(filebytes[bpi, 1]) >> 2
 
         # Set defaults or carry over previous values if necessary
         subtype, chan, num, aux_note = update_extra_fields(
@@ -2236,7 +2236,7 @@ def proc_core_fields(filebytes, bpi):
         bpi = bpi + 3
 
     # Not a skip - it is the actual sample number + annotation type store value
-    label_store = filebytes[bpi, 1] >> 2
+    label_store = int(filebytes[bpi, 1]) >> 2
     sample_diff += np.int64(filebytes[bpi, 0]) + 256 * np.int64(
         filebytes[bpi, 1] & 3
     )

--- a/wfdb/io/annotation.py
+++ b/wfdb/io/annotation.py
@@ -2237,8 +2237,8 @@ def proc_core_fields(filebytes, bpi):
 
     # Not a skip - it is the actual sample number + annotation type store value
     label_store = int(filebytes[bpi, 1]) >> 2
-    sample_diff += np.int64(filebytes[bpi, 0]) + 256 * np.int64(
-        filebytes[bpi, 1] & 3
+    sample_diff += np.int64(filebytes[bpi, 0]) + 256 * (
+        np.int64(filebytes[bpi, 1]) & 3
     )
     bpi = bpi + 1
 
@@ -2324,7 +2324,7 @@ def proc_extra_field(
         aux_notebytes = filebytes[
             bpi + 1 : bpi + 1 + int(np.ceil(aux_notelen / 2.0)), :
         ].flatten()
-        if aux_notelen & 1:
+        if int(aux_notelen) & 1:
             aux_notebytes = aux_notebytes[:-1]
         # The aux_note string
         aux_note.append("".join([chr(char) for char in aux_notebytes]))


### PR DESCRIPTION
As discussed in https://github.com/MIT-LCP/wfdb-python/issues/493, numpy v2.0 introduced changes to type promotion rules: https://numpy.org/devdocs/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion

Running pytest with `numpy==2.0.2` and `NPY_PROMOTION_STATE=weak_and_warn` raises the following warnings for wfdb/io/annotation.py:

```
  /Users/tompollard/projects/wfdb-python/wfdb/io/annotation.py:2222: UserWarning: result dtype changed due to the removal of value-based promotion from NumPy. Changed from int64 to uint8.
    while filebytes[bpi, 1] >> 2 == 59:

  /Users/tompollard/projects/wfdb-python/wfdb/io/annotation.py:2239: UserWarning: result dtype changed due to the removal of value-based promotion from NumPy. Changed from int64 to uint8.
    label_store = filebytes[bpi, 1] >> 2

tests/test_plot.py::TestPlotInternal::test_get_plot_dims
  /Users/tompollard/projects/wfdb-python/wfdb/io/annotation.py:2240: UserWarning: result dtype changed due to the removal of value-based promotion from NumPy. Changed from int64 to uint8.
    sample_diff += int(filebytes[bpi, 0] + 256 * (filebytes[bpi, 1] & 3))
```

The changes in this pull request address these issues by explicitly casting the type. I plan to follow up with several additional fixes to other modules.