### PR TITLE
Change in type promotion. Fixes to _signal.py

### DIFF
--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -2319,11 +2319,10 @@ def wr_dat_file(
 
     if fmt == "80":
         # convert to 8 bit offset binary form
-        d_signal = d_signal + 128
-        # Concatenate into 1D
-        d_signal = d_signal.reshape(-1)
-        # Convert to un_signed 8 bit dtype to write
-        b_write = d_signal.astype("uint8")
+        d_signal += 128
+
+        # Convert to unsigned 8 bit dtype to write (and flatten if necessary)
+        b_write = d_signal.astype("uint8").reshape(-1)
 
     elif fmt == "212":
         # Each sample is represented by a 12 bit two's complement
@@ -2336,7 +2335,7 @@ def wr_dat_file(
         # repeated for each successive pair of samples.
 
         # convert to 12 bit two's complement
-        d_signal[d_signal < 0] = d_signal[d_signal < 0] + 4096
+        d_signal[d_signal < 0] += 4096
 
         # Concatenate into 1D
         d_signal = d_signal.reshape(-1)
@@ -2384,8 +2383,8 @@ def wr_dat_file(
         # Convert to un_signed 8 bit dtype to write
         b_write = b_write.astype("uint8")
     elif fmt == "24":
-        # convert to 24 bit two's complement
-        d_signal[d_signal < 0] = d_signal[d_signal < 0] + 16777216
+        # convert to 32 bit two's complement (as int24 not an option)
+        d_signal = d_signal.astype(np.uint32)
         # Split samples into separate bytes using binary masks
         b1 = d_signal & [255] * tsamps_per_frame
         b2 = (d_signal & [65280] * tsamps_per_frame) >> 8

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -2371,7 +2371,8 @@ def wr_dat_file(
 
     elif fmt == "16":
         # convert to 16 bit two's complement
-        d_signal[d_signal < 0] = d_signal[d_signal < 0] + 65536
+        d_signal = d_signal.astype(np.uint16)
+
         # Split samples into separate bytes using binary masks
         b1 = d_signal & [255] * tsamps_per_frame
         b2 = (d_signal & [65280] * tsamps_per_frame) >> 8
@@ -2400,7 +2401,8 @@ def wr_dat_file(
 
     elif fmt == "32":
         # convert to 32 bit two's complement
-        d_signal[d_signal < 0] = d_signal[d_signal < 0] + 4294967296
+        d_signal = d_signal.astype(np.uint32)
+
         # Split samples into separate bytes using binary masks
         b1 = d_signal & [255] * tsamps_per_frame
         b2 = (d_signal & [65280] * tsamps_per_frame) >> 8


### PR DESCRIPTION
As discussed in https://github.com/MIT-LCP/wfdb-python/issues/493, numpy v2.0 introduced changes to type promotion rules: https://numpy.org/devdocs/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion

Running pytest with `numpy==2.0.2` and `NPY_PROMOTION_STATE=weak_and_warn` raises the following warning for wfdb/io/_signal.py:

```
tests/test_record.py::TestRecord::test_1a
  /Users/tompollard/projects/wfdb-python/wfdb/io/_signal.py:2374: UserWarning: result dtype changed due to the removal of value-based promotion from NumPy. Changed from int32 to int16.
    d_signal[d_signal < 0] = d_signal[d_signal < 0] + 65536
```

The changes in this pull request address these issues by explicitly casting the type. I also make a couple of minor modifications for efficiency (switching to inplace addition). I plan to follow up with several additional fixes to other modules.