### PR TITLE
Change in type promotion. Fixes to edf.py

### DIFF
--- a/wfdb/io/convert/edf.py
+++ b/wfdb/io/convert/edf.py
@@ -402,22 +402,28 @@ def read_edf(
     temp_sig_data = np.fromfile(edf_file, dtype=np.int16)
     temp_sig_data = temp_sig_data.reshape((-1, sum(samps_per_block)))
     temp_all_sigs = np.hsplit(temp_sig_data, np.cumsum(samps_per_block)[:-1])
+
     for i in range(n_sig):
         # Check if `samps_per_frame` has all equal values
         if samps_per_frame.count(samps_per_frame[0]) == len(samps_per_frame):
             sig_data[:, i] = (
-                temp_all_sigs[i].flatten() - baseline[i]
+                (temp_all_sigs[i].flatten() - baseline[i]).astype(np.int64)
             ) / adc_gain_all[i]
         else:
             temp_sig_data = temp_all_sigs[i].flatten()
+
             if samps_per_frame[i] == 1:
-                sig_data[:, i] = (temp_sig_data - baseline[i]) / adc_gain_all[i]
+                sig_data[:, i] = (temp_sig_data - baseline[i]).astype(
+                    np.int64
+                ) / adc_gain_all[i]
             else:
                 for j in range(sig_len):
                     start_ind = j * samps_per_frame[i]
                     stop_ind = start_ind + samps_per_frame[i]
                     sig_data[j, i] = np.mean(
-                        (temp_sig_data[start_ind:stop_ind] - baseline[i])
+                        (
+                            temp_sig_data[start_ind:stop_ind] - baseline[i]
+                        ).astype(np.int64)
                         / adc_gain_all[i]
                     )
 


### PR DESCRIPTION
As discussed in https://github.com/MIT-LCP/wfdb-python/issues/493, numpy v2.0 introduced changes to type promotion rules: https://numpy.org/devdocs/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion

Running pytest with `numpy==2.0.2` and `NPY_PROMOTION_STATE=weak_and_warn` raises the following warning for wfdb/io/convert/edf.py:

```
tests/io/test_convert.py::TestEdfToWfdb::test_edf_uniform
  /Users/tompollard/projects/wfdb-python/wfdb/io/convert/edf.py:409: UserWarning: result dtype changed due to the removal of value-based promotion from NumPy. Changed from int16 to int64.
    temp_all_sigs[i].flatten() - baseline[i]

tests/io/test_convert.py::TestEdfToWfdb::test_edf_non_uniform
  /Users/tompollard/projects/wfdb-python/wfdb/io/convert/edf.py:420: UserWarning: result dtype changed due to the removal of value-based promotion from NumPy. Changed from int16 to int64.
    (temp_sig_data[start_ind:stop_ind] - baseline[i])

tests/io/test_convert.py::TestEdfToWfdb::test_edf_non_uniform
  /Users/tompollard/projects/wfdb-python/wfdb/io/convert/edf.py:414: UserWarning: result dtype changed due to the removal of value-based promotion from NumPy. Changed from int16 to int64.
    sig_data[:, i] = (temp_sig_data - baseline[i]) / adc_gain_all[i]
```

The changes in this pull request address these issues by explicitly casting the type.