### PR TITLE
Test round-trip write/read of supported binary formats

### DIFF
--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -227,6 +227,27 @@ class TestRecord(unittest.TestCase):
                             "Mismatch in %s" % name,
                         )
 
+        # Test writing all supported formats.  (Currently not all signal
+        # formats are supported for output; keep this list in sync with
+        # 'wr_dat_file' in wfdb/io/_signal.py.)
+        OUTPUT_FMTS = ["80", "212", "16", "24", "32"]
+        channels = []
+        for i, fmt in enumerate(record.fmt):
+            if fmt in OUTPUT_FMTS:
+                channels.append(i)
+
+        partial_record = wfdb.rdrecord(
+            "sample-data/binformats",
+            physical=False,
+            channels=channels,
+        )
+        partial_record.wrsamp(write_dir=self.temp_path)
+        converted_record = wfdb.rdrecord(
+            os.path.join(self.temp_path, "binformats"),
+            physical=False,
+        )
+        assert partial_record == converted_record
+
     def test_read_write_flac(self):
         """
         All FLAC formats, multiple signal files in one record.


### PR DESCRIPTION
We want to test that both reading and writing work correctly for all supported formats (although currently some binary formats are completely unsupported for writing.)

Previous test cases covered formats 80, 212, 16, and 24 (and the FLAC formats) but did not cover format 32.
