### PR TITLE
Set pytest to run in NPY_PROMOTION_STATE=weak_and_warn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dynamic = ["version"]
 dev = [
     "pytest >= 7.1.1",
     "pytest-xdist >= 2.5.0",
+    "pytest-env >= 1.1.5",
     "pylint >= 2.13.7",
     "black >= 22.3.0",
     "sphinx >= 4.5.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+env =
+    NPY_PROMOTION_STATE=weak_and_warn


### PR DESCRIPTION
As discussed in https://github.com/MIT-LCP/wfdb-python/issues/493, numpy 2.0 introduced changes to type promotion. The change is outlined at: https://numpy.org/devdocs/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion

This pull request:
- adds a pytest.ini that sets `NPY_PROMOTION_STATE` to `weak_and_warn` to help us catch problems that need fixing before we support Numpy > 2.
- adds a dev dependency on `pytest-env` (to add support for pytest.ini).