### PR TITLE
Adds changelog for v4.2.0.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,37 @@ This page lists recent changes in the `wfdb` package (since version 4.0.0) that 
 
 .. _development repository: https://github.com/MIT-LCP/wfdb-python
 
+Version 4.2.0 (Jan 2025)
+-----------------------------
+
+**Add support for Numpy 2.0**
+  Fixes were added to address [changes to type promotion](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion) that led to overflow errors (e.g. https://github.com/MIT-LCP/wfdb-python/issues/493). 
+
+**Fix UnboundLocalError in GQRS algorithm**
+  Fixes the GQRS algorithm to address an `UnboundLocalError`.
+
+**Support write directory in `csv_to_wfdb`**
+  `write_dir` can now be specified when calling `csv_to_wfdb`.
+
+**Use uv for for package management**
+  Moves package management from poetry to uv.
+
+**Fix misordered arguments in `util.lines_to_file`**
+  Fixes misordered arguments in `util.lines_to_file`.
+
+**Allow signals to be written with unique samples per frame**
+  Adds capability to write signal with unique samps_per_frame to `wfdb.io.wrsamp`.
+
+**Allow expanded physical signal in `calc_adc_params`**
+  Updates `calc_adc_params` to allow an expanded physical signal to be passed. Previously only a non-expanded signal was allowed.
+
+**Allow selection of channels when converting to EDF**
+  Fixes the `wfdb-to_edf()` function to support an optional channels argument.
+
+**Miscellaneous style and typing fixes**
+  Various fixes were made to code style and handling of data types.
+
+
 Version 4.1.2 (June 2023)
 -----------------------------
 


### PR DESCRIPTION
This pull request adds a changelog for `v4.2.0`. The changelog is based on the following auto-generated summary of merge commits generated by GitHub:

```
## What's Changed

* bug-fix: Numpy ValueError when cheking empty list equality by @ajadczaksunriselabs in https://github.com/MIT-LCP/wfdb-python/pull/459
* bug-fix: Pandas set indexing error by @ajadczaksunriselabs in https://github.com/MIT-LCP/wfdb-python/pull/460
* fix for MIT-LCP/wfdb-python/issues/452 by @tecamenz in https://github.com/MIT-LCP/wfdb-python/pull/465
* Use numpydoc to render documentation by @SnoopJ in https://github.com/MIT-LCP/wfdb-python/pull/472
* build(deps): bump readthedocs-sphinx-search from 0.1.1 to 0.3.2 in /docs by @dependabot in https://github.com/MIT-LCP/wfdb-python/pull/477
* Update style by @bemoody in https://github.com/MIT-LCP/wfdb-python/pull/482
* Fix NaN handling in Record.adc, and other fixes by @bemoody in https://github.com/MIT-LCP/wfdb-python/pull/481
* Set upper bound on Numpy version (numpy = ">=1.10.1,<2.0.0"). Ref #493. by @tompollard in https://github.com/MIT-LCP/wfdb-python/pull/494
* Update actions to use actions/checkout@v3 and actions/setup-python@v4. by @tompollard in https://github.com/MIT-LCP/wfdb-python/pull/495
* Fix: Indent code to ensure 'j' is within for-loop in GQRS algorithm by @tompollard in https://github.com/MIT-LCP/wfdb-python/pull/499
* Add write_dir argument to csv_to_wfdb. Fixes #67. by @tompollard in https://github.com/MIT-LCP/wfdb-python/pull/492
* Fix warnings by @cbrnr in https://github.com/MIT-LCP/wfdb-python/pull/502
* README improvements by @bemoody in https://github.com/MIT-LCP/wfdb-python/pull/503
* Change in type promotion. Fixes to annotation.py by @tompollard in https://github.com/MIT-LCP/wfdb-python/pull/506
* Use uv by @cbrnr in https://github.com/MIT-LCP/wfdb-python/pull/504
* Change in type promotion. Fixes to _signal.py by @tompollard in https://github.com/MIT-LCP/wfdb-python/pull/507
* Test round-trip write/read of supported binary formats by @bemoody in https://github.com/MIT-LCP/wfdb-python/pull/509
* Corrected typo and extended allowed types for MultiSegmentRecord by @agent3gatech in https://github.com/MIT-LCP/wfdb-python/pull/514
* Allow expanded physical signal in `calc_adc_params` by @briangow in https://github.com/MIT-LCP/wfdb-python/pull/512
* Add capability to write signal with unique `samps_per_frame` to `wfdb.io.wrsamp` by @briangow in https://github.com/MIT-LCP/wfdb-python/pull/510
* Fix selection of channels when converting to EDF by @SamJelfs in https://github.com/MIT-LCP/wfdb-python/pull/519
* Change in type promotion introduced in Numpy 2.0. Fixes to edf.py. by @tompollard in https://github.com/MIT-LCP/wfdb-python/pull/527
* Bump dependencies for NumPy 2 compatibility by @cbrnr in https://github.com/MIT-LCP/wfdb-python/pull/511
* Bump version to v4.2.0 and update notes on creating new releases by @tompollard in https://github.com/MIT-LCP/wfdb-python/pull/497

## New Contributors

* @ajadczaksunriselabs made their first contribution in https://github.com/MIT-LCP/wfdb-python/pull/459
* @tecamenz made their first contribution in https://github.com/MIT-LCP/wfdb-python/pull/465
* @SnoopJ made their first contribution in https://github.com/MIT-LCP/wfdb-python/pull/472
* @dependabot made their first contribution in https://github.com/MIT-LCP/wfdb-python/pull/477
* @agent3gatech made their first contribution in https://github.com/MIT-LCP/wfdb-python/pull/514
* @SamJelfs made their first contribution in https://github.com/MIT-LCP/wfdb-python/pull/519

**Full Changelog**: https://github.com/MIT-LCP/wfdb-python/compare/v4.1.2...v4.2.0
```