### PR TITLE
Bump Sphinx to 7.0.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,7 +82,7 @@ release = __version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-numpydoc<1.6
-sphinx==4.5.0
-sphinx_rtd_theme==1.0.0
+numpydoc==1.7.0
+sphinx==7.0.0
+sphinx_rtd_theme==3.0.0
 readthedocs-sphinx-search==0.3.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dev = [
     "pytest-xdist >= 2.5.0",
     "pylint >= 2.13.7",
     "black >= 22.3.0",
-    "sphinx >= 4.5.0",
+    "sphinx >= 7.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
readthedocs [is failing](https://app.readthedocs.org/projects/wfdb/builds/23195231/) with the following error: 

```
Running Sphinx v4.5.0
loading translations [en]... done
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/wfdb/envs/latest/lib/python3.9/site-packages/sphinx/registry.py", line 438, in load_extension
    metadata = setup(app)
  File "/home/docs/checkouts/readthedocs.org/user_builds/wfdb/envs/latest/lib/python3.9/site-packages/sphinxcontrib/applehelp/__init__.py", line 230, in setup
    app.require_sphinx('5.0')
  File "/home/docs/checkouts/readthedocs.org/user_builds/wfdb/envs/latest/lib/python3.9/site-packages/sphinx/application.py", line 393, in require_sphinx
    raise VersionRequirementError(version)
sphinx.errors.VersionRequirementError: 5.0
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/wfdb/envs/latest/lib/python3.9/site-packages/sphinx/cmd/build.py", line 272, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
  File "/home/docs/checkouts/readthedocs.org/user_builds/wfdb/envs/latest/lib/python3.9/site-packages/sphinx/application.py", line 219, in __init__
    self.setup_extension(extension)
  File "/home/docs/checkouts/readthedocs.org/user_builds/wfdb/envs/latest/lib/python3.9/site-packages/sphinx/application.py", line 380, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/wfdb/envs/latest/lib/python3.9/site-packages/sphinx/registry.py", line 441, in load_extension
    raise VersionRequirementError(
sphinx.errors.VersionRequirementError: The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
Sphinx version error:
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
```

This pull request fixes the build by: 

- bumping the version of Sphinx to 7.0.0
- fixing the language to "en" in the configuration file
