### PR TITLE
Bugfix: Update summary printing when writing EDF files.

### DIFF
--- a/wfdb/io/convert/edf.py
+++ b/wfdb/io/convert/edf.py
@@ -959,12 +959,12 @@ def wfdb_to_edf(
                 [
                     num_blocks,
                     num_blocks * int(frames_per_block),
-                    num_blocks * bytes_per_block,
+                    num_blocks * int(bytes_per_block),
                 ]
             ),
             num_blocks,
             num_blocks * int(frames_per_block),
-            num_blocks * bytes_per_block,
+            num_blocks * int(bytes_per_block),
         )
     )
     print(


### PR DESCRIPTION
When writing an EDF file the summary of recording length is printed to console. If the number of bytes per block is not an integer this fails with `ValueError: Unknown format code 'd' for object of type 'float'`. Ensure cast to int first.