### PR TITLE
Add `fsspec` to Read The Docs requirement

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ numpydoc==1.7.0
 sphinx==7.0.0
 sphinx_rtd_theme==3.0.0
 readthedocs-sphinx-search==0.3.2
+fsspec>=2023.10.0


### PR DESCRIPTION
Currently the Read The Docs pages for this repo aren't providing the detailed information for the functions (only the landing page is working as expected). The Read The Docs build says that it succeeded but gives errors about not being able able to find the `fsspec` module, see the [log](https://app.readthedocs.org/api/v2/build/27889860.txt) for more detail. 

I've added `fsspec` to `docs/requirements.txt` to fix this issue. 
