### PR TITLE
Read The Docs workflow - upgrade from deprecated Ubuntu version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies


### PR DESCRIPTION
This PR updates the Ubuntu runner for the Read The Docs workflow to the next stable version (22.04) since the current version 20.04 was deprecated two days ago:

`This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15.`