### PR TITLE
WIP: Add support for reading and writing .wfdb archive files

### DIFF
--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,189 @@
+import os
+import numpy as np
+import pytest
+import tempfile
+import zipfile
+
+from wfdb import rdrecord, wrsamp
+from wfdb.io.archive import WFDBArchive
+
+
+np.random.seed(1234)
+
+
+@pytest.fixture
+def temp_record():
+    """
+    Create a temporary WFDB record and archive for testing.
+
+    This fixture generates a synthetic 2-channel signal, writes it to a temporary
+    directory using `wrsamp`, then creates an uncompressed `.wfdb` archive (ZIP container)
+    containing the `.hea` and `.dat` files. The archive is used to test read/write
+    round-trip support for WFDB archives.
+
+    Yields
+    ------
+    dict
+        A dictionary containing:
+        - 'record_name': Path to the record base name (without extension).
+        - 'archive_path': Full path to the created `.wfdb` archive.
+        - 'original_signal': The original NumPy array of the signal.
+        - 'fs': The sampling frequency.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        record_basename = "testrecord"
+        fs = 250
+        sig_len = 1000
+        sig = (np.random.randn(sig_len, 2) * 1000).astype(np.float32)
+
+        # Write into tmpdir with record name only
+        wrsamp(
+            record_name=record_basename,
+            fs=fs,
+            units=["mV", "mV"],
+            sig_name=["I", "II"],
+            p_signal=sig,
+            fmt=["24", "24"],
+            adc_gain=[200.0, 200.0],
+            baseline=[0, 0],
+            write_dir=tmpdir,
+        )
+
+        # Construct full paths for archive creation
+        hea_path = os.path.join(tmpdir, record_basename + ".hea")
+        dat_path = os.path.join(tmpdir, record_basename + ".dat")
+        archive_path = os.path.join(tmpdir, record_basename + ".wfdb")
+
+        WFDBArchive.create_archive(
+            None,
+            file_list=[hea_path, dat_path],
+            output_path=archive_path,
+        )
+
+        yield {
+            "record_name": os.path.join(tmpdir, record_basename),
+            "archive_path": archive_path,
+            "original_signal": sig,
+            "fs": fs,
+        }
+
+
+def test_wfdb_archive_inline_round_trip():
+    """
+    There are two ways of creating an archive:
+
+    1. Inline archive creation via wrsamp(..., wfdb_archive=...)
+    This creates the .hea and .dat files directly inside the archive as part of the record writing step.
+
+    2. Two-step creation via wrsamp(...) followed by WFDBArchive.create_archive(...)
+    This writes regular WFDB files to disk, which are then added to an archive container afterward.
+
+    Test round-trip read/write using inline archive creation via `wrsamp(..., wfdb_archive=...)`.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        record_basename = "testrecord"
+        record_path = os.path.join(tmpdir, record_basename)
+        archive_path = record_path + ".wfdb"
+        fs = 250
+        sig_len = 1000
+        sig = (np.random.randn(sig_len, 2) * 1000).astype(np.float32)
+
+        # Create archive inline
+        wfdb_archive = WFDBArchive(record_basename, mode="w")
+        wrsamp(
+            record_name=record_basename,
+            fs=fs,
+            units=["mV", "mV"],
+            sig_name=["I", "II"],
+            p_signal=sig,
+            fmt=["24", "24"],
+            adc_gain=[200.0, 200.0],
+            baseline=[0, 0],
+            write_dir=tmpdir,
+            wfdb_archive=wfdb_archive,
+        )
+        wfdb_archive.close()
+
+        assert os.path.exists(archive_path), "Archive was not created"
+
+        # Read back from archive
+        record = rdrecord(archive_path)
+
+        assert record.fs == fs
+        assert record.n_sig == 2
+        assert record.p_signal.shape == sig.shape
+
+        # Add tolerance to account for loss of precision during archive round-trip
+        np.testing.assert_allclose(record.p_signal, sig, rtol=1e-2, atol=3e-3)
+
+
+def test_wfdb_archive_round_trip(temp_record):
+    record_name = temp_record["record_name"]
+    archive_path = temp_record["archive_path"]
+    original_signal = temp_record["original_signal"]
+    fs = temp_record["fs"]
+
+    assert os.path.exists(archive_path), "Archive was not created"
+
+    record = rdrecord(archive_path)
+
+    assert record.fs == fs
+    assert record.n_sig == 2
+    assert record.p_signal.shape == original_signal.shape
+
+    # Add tolerance to account for loss of precision during archive round-trip
+    np.testing.assert_allclose(record.p_signal, original_signal, rtol=1e-2,
+                               atol=3e-3)
+
+
+def test_archive_read_subset_channels(temp_record):
+    """
+    Test reading a subset of channels from an archive.
+    """
+    archive_path = temp_record["archive_path"]
+    original_signal = temp_record["original_signal"]
+
+    record = rdrecord(archive_path, channels=[1])
+
+    assert record.n_sig == 1
+    assert record.p_signal.shape[0] == original_signal.shape[0]
+
+    # Add tolerance to account for loss of precision during archive round-trip
+    np.testing.assert_allclose(record.p_signal[:, 0], original_signal[:, 1],
+                               rtol=1e-2, atol=3e-3)
+
+
+def test_archive_read_partial_samples(temp_record):
+    """
+    Test reading a sample range from the archive.
+    """
+    archive_path = temp_record["archive_path"]
+    original_signal = temp_record["original_signal"]
+
+    start, stop = 100, 200
+    record = rdrecord(archive_path, sampfrom=start, sampto=stop)
+
+    assert record.p_signal.shape == (stop - start, original_signal.shape[1])
+    np.testing.assert_allclose(record.p_signal, original_signal[start:stop], rtol=1e-2, atol=1e-3)
+
+
+def test_archive_missing_file_error(temp_record):
+    """
+    Ensure appropriate error is raised when expected files are missing from the archive.
+    """
+    archive_path = temp_record["archive_path"]
+
+    # Remove one file from archive (e.g. the .dat file)
+    with zipfile.ZipFile(archive_path, "a") as zf:
+        zf_name = [name for name in zf.namelist() if name.endswith(".dat")][0]
+        zf.fp = None  # Prevent auto-close bug in some zipfile implementations
+    os.rename(archive_path, archive_path + ".bak")
+    with zipfile.ZipFile(archive_path + ".bak", "r") as zin, \
+         zipfile.ZipFile(archive_path, "w") as zout:
+        for item in zin.infolist():
+            if not item.filename.endswith(".dat"):
+                zout.writestr(item, zin.read(item.filename))
+    os.remove(archive_path + ".bak")
+
+    with pytest.raises(FileNotFoundError, match=".*\.dat.*"):
+        rdrecord(archive_path)

--- a/wfdb/io/_signal.py
+++ b/wfdb/io/_signal.py
@@ -2574,7 +2574,7 @@ def wr_dat_file(
     # Write the bytes to the file
     if wfdb_archive:
         with io.BytesIO() as f:
-            b_write.tofile(f)
+            f.write(b_write.tobytes())
             wfdb_archive.write(os.path.basename(file_name), f.getvalue())
     else:
         with open(file_path, "wb") as f:

--- a/wfdb/io/archive.py
+++ b/wfdb/io/archive.py
@@ -1,0 +1,85 @@
+import os
+import zipfile
+from contextlib import contextmanager
+
+_archive_cache = {}
+
+
+class WFDBArchive:
+    """
+    Helper class for working with WFDB .wfdb ZIP archives.
+
+    Used only if:
+      - .wfdb is included in the record_name explicitly, or
+      - .wfdb is passed directly to the file loading function.
+    """
+    def __init__(self, record_name):
+        """
+        Initialize a WFDBArchive for a given record name (without extension).
+
+        record_name : str
+          The base name of the archive, without the .wfdb extension.
+        """
+        self.record_name = record_name
+        self.archive_path = f"{record_name}.wfdb"
+
+        if not os.path.exists(self.archive_path):
+            raise FileNotFoundError(f"Archive not found: {self.archive_path}")
+        if not zipfile.is_zipfile(self.archive_path):
+            raise ValueError(f"Invalid WFDB archive: {self.archive_path}")
+        self.zipfile = zipfile.ZipFile(self.archive_path, mode="r")
+
+    def exists(self, filename):
+        """
+        Check if a file exists in the archive.
+        """
+        return self.zipfile and filename in self.zipfile.namelist()
+
+    @contextmanager
+    def open(self, filename, mode="r"):
+        """
+        Open a file, either from disk or from the archive.
+        Mode 'r' (text) or 'rb' (binary) supported.
+        """
+        if self.zipfile and filename in self.zipfile.namelist():
+            with self.zipfile.open(filename, 'r') as f:
+                if "b" in mode:
+                    yield f
+                else:
+                    import io
+                    yield io.TextIOWrapper(f)
+        else:
+            raise FileNotFoundError(
+                f"Could not find '{filename}' as loose file or inside '{self.archive_path}'."
+                )
+
+    def close(self):
+        """
+        Close the archive if open.
+        """
+        if self.zipfile:
+            self.zipfile.close()
+
+    def create_archive(self, file_list, output_path=None):
+        """
+        Create a .wfdb archive containing the specified list of files.
+        If output_path is not specified, uses self.archive_path.
+        """
+        output_path = output_path or self.archive_path
+        with zipfile.ZipFile(output_path, mode="w") as zf:
+            for file in file_list:
+                compress = (
+                    zipfile.ZIP_STORED
+                    if file.endswith((".hea", ".hea.json", ".hea.yml"))
+                    else zipfile.ZIP_DEFLATED
+                )
+                zf.write(file, arcname=os.path.basename(file), compress_type=compress)
+
+
+def get_archive(record_base_name):
+    """
+    Get or create a WFDBArchive for the given record base name.
+    """
+    if record_base_name not in _archive_cache:
+        _archive_cache[record_base_name] = WFDBArchive(record_base_name)
+    return _archive_cache[record_base_name]

--- a/wfdb/io/archive.py
+++ b/wfdb/io/archive.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import zipfile
 from contextlib import contextmanager
 
@@ -59,6 +60,23 @@ class WFDBArchive:
         """
         if self.zipfile:
             self.zipfile.close()
+
+    def write(self, filename, data):
+        """
+        Write binary data to the archive (replaces if already exists).
+        """
+        # Write to a new temporary archive
+        tmp_path = self.archive_path + ".tmp"
+        with zipfile.ZipFile(self.archive_path, mode="r") as zin:
+            with zipfile.ZipFile(tmp_path, mode="w") as zout:
+                for item in zin.infolist():
+                    if item.filename != filename:
+                        zout.writestr(item, zin.read(item.filename))
+                zout.writestr(filename, data)
+
+        # Replace the original archive
+        shutil.move(tmp_path, self.archive_path)
+        self.zipfile = zipfile.ZipFile(self.archive_path, mode="a")
 
     def create_archive(self, file_list, output_path=None):
         """

--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -905,7 +905,7 @@ class Record(BaseRecord, _header.HeaderMixin, _signal.SignalMixin):
 
         return True
 
-    def wrsamp(self, expanded=False, write_dir=""):
+    def wrsamp(self, expanded=False, write_dir="", wfdb_archive=None):
         """
         Write a WFDB header file and any associated dat files from this
         object.
@@ -939,7 +939,8 @@ class Record(BaseRecord, _header.HeaderMixin, _signal.SignalMixin):
         if self.n_sig > 0:
             # Perform signal validity and cohesion checks, and write the
             # associated dat files.
-            self.wr_dats(expanded=expanded, write_dir=write_dir)
+            self.wr_dats(expanded=expanded, write_dir=write_dir, 
+                         wfdb_archive=wfdb_archive)
 
     def _arrange_fields(self, channels, sampfrom, smooth_frames):
         """
@@ -2878,6 +2879,7 @@ def wrsamp(
     base_date=None,
     base_datetime=None,
     write_dir="",
+    archive=False,
 ):
     """
     Write a single segment WFDB record, creating a WFDB header file and any
@@ -2966,6 +2968,7 @@ def wrsamp(
     # Check for valid record name
     if "." in record_name:
         raise Exception("Record name must not contain '.'")
+
     # Check input field combinations
     signal_list = [p_signal, d_signal, e_p_signal, e_d_signal]
     signals_set = sum(1 for var in signal_list if var is not None)
@@ -3064,8 +3067,12 @@ def wrsamp(
     else:
         expanded = False
 
+    wfdb_archive = None
+    if archive:
+        wfdb_archive = get_archive(os.path.join(write_dir, record_name))
+
     # Write the record files - header and associated dat
-    record.wrsamp(write_dir=write_dir, expanded=expanded)
+    record.wrsamp(write_dir=write_dir, expanded=expanded, wfdb_archive=wfdb_archive)
 
 
 def dl_database(


### PR DESCRIPTION
As discussed in https://github.com/wfdb/wfdb-spec/issues/21 and https://github.com/MIT-LCP/wfdb-python/issues/540 we would like to allow WFDB Records to be saved to a single file `.wfdb`.

This pull request introduces support for reading and writing `.wfdb` archive files, a ZIP-based format that stores .hea, .dat, and related files in a single container.

### Reading `.wfdb` files

- 

### Writing `.wfdb` files

- 

### Notes

-  
