### PR TITLE
Split style checks into separate workflow

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,21 @@
+name: Style Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  style:
+    name: Style Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - name: Install Python
+        run: uv python install 3.11
+      - name: Check style
+        run: uv run --extra dev black --check --diff .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,6 @@ jobs:
         run: sudo apt-get install -y libsndfile1
       - name: Run tests
         run: uv run --with ${{ matrix.numpy }} --extra dev pytest
-      - name: Check style
-        run: uv run --extra dev black --check --diff .
 
   test-deb11-i386:
     name: Python 3.7 on Debian 11 i386


### PR DESCRIPTION
Currently, style checks are integrated with functional tests in the same workflow. This meant that any style issues cause the entire test suite to fail.

This pull request:

- Creates a new workflow file `.github/workflows/style.yml` for style checks
- Removes style check step from the test workflow

The benefit of making this change is that it becomes easier to identify whether issues are related to code style or functionality. 