### PR TITLE
Update `MultiHeaderMixin` header formatting to match `HeaderMixin` formatting

### DIFF
--- a/wfdb/io/_header.py
+++ b/wfdb/io/_header.py
@@ -1,4 +1,5 @@
 import datetime
+from dateutil import parser
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
@@ -240,7 +241,8 @@ class BaseHeaderMixin(object):
         """
         Get and process the fields as needed before writing
         """
-        string_field = str(getattr(self, field))
+        original_field = getattr(self, field)
+        string_field = str(original_field)
 
         # Certain fields need extra processing
         if field == "fs" and isinstance(self.fs, float):
@@ -249,9 +251,7 @@ class BaseHeaderMixin(object):
         elif field == "base_time" and "." in string_field:
             string_field = string_field.rstrip("0")
         elif field == "base_date":
-            string_field = "/".join(
-                (string_field[8:], string_field[5:7], string_field[:4])
-            )
+            string_field = original_field.strftime("%d/%m/%Y")
 
         return string_field
 


### PR DESCRIPTION
In 63c987f33098aa0ccded214115d7922a7d0b9325 updates to `HeaderMixin` were made to properly format the header date and time fields. This fix did not make it into `MultiHeaderMixin` (for multi-segment records). Therefore, writing a date using the `wrheader` method under `MultiHeaderMixin` currently results in writing the `base_date` as YYYY-MM-DD which isn't compatible with the DD/MM/YYYY format requirement. 

This PR updated `MultiHeaderMixin` by using the code from `HeaderMixin` to properly set formats. 