### PR TITLE
Limit `NPY_PROMOTION_STATE` to `i386` test job only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - main
 
-env:
-  NPY_PROMOTION_STATE: weak_and_warn
-
 jobs:
   test:
     name: Python ${{ matrix.python-version }} / ${{ matrix.os }} / ${{ matrix.numpy }}
@@ -40,6 +37,8 @@ jobs:
     name: Python 3.7 on Debian 11 i386
     runs-on: ubuntu-latest
     container: i386/debian:11
+    env:
+      NPY_PROMOTION_STATE: weak_and_warn
     steps:
       - name: Install dependencies
         run: |


### PR DESCRIPTION
As discussed in #548, we need to fix a failing test. 

This PR removes the global `NPY_PROMOTION_STATE: weak_and_warn` environment variable and applies it only to the `test-deb11-i386` job where overflow errors are most likely to occur in the 32-bit environment. 

Addresses test overflow errors seen in #544. Note that the `test-deb11-i386` job is not failing. 