### PR TITLE
Allow expanded parameter in `MultiRecord.wrsamp`

### DIFF
--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -1160,13 +1160,17 @@ class MultiRecord(BaseRecord, _header.MultiHeaderMixin):
             if not seg_len:
                 self.seg_len = [segment.sig_len for segment in segments]
 
-    def wrsamp(self, write_dir=""):
+    def wrsamp(self, expanded=False, write_dir=""):
         """
         Write a multi-segment header, along with headers and dat files
         for all segments, from this object.
 
         Parameters
         ----------
+        expanded : bool, optional
+            Whether to write each segment's expanded signal (`e_d_signal`)
+            instead of the uniform signal (`d_signal`). This flag is passed
+            through to each segment's `Record.wrsamp()` call.
         write_dir : str, optional
             The directory in which to write the files.
 
@@ -1181,7 +1185,7 @@ class MultiRecord(BaseRecord, _header.MultiHeaderMixin):
         # Perform record validity and cohesion checks, and write the
         # associated segments.
         for seg in self.segments:
-            seg.wrsamp(write_dir=write_dir)
+            seg.wrsamp(expanded=expanded, write_dir=write_dir)
 
     def _check_segment_cohesion(self):
         """


### PR DESCRIPTION
As raised in #554, `wfdb.io.Multirecord.wrsamp` does not provide the option to pass `expanded=True`. This should be provided so that multifrequency signals can be written within the `Multirecord` class. This PR updates the `wrsamp` call to allow for `expanded` to be passed. 