### PR TITLE
Clarify expanded signal format in docstrings

### DIFF
--- a/wfdb/io/record.py
+++ b/wfdb/io/record.py
@@ -712,11 +712,9 @@ class Record(BaseRecord, _header.HeaderMixin, _signal.SignalMixin):
         must be set, but not both. In addition, if d_signal is set, fmt, gain
         and baseline must also all be set.
     e_p_signal : ndarray, optional
-        The expanded physical conversion of the signal. Either a 2d numpy
-        array or a list of 1d numpy arrays.
+        The expanded physical conversion of the signal as a list of 1d numpy arrays.
     e_d_signal : ndarray, optional
-        The expanded digital conversion of the signal. Either a 2d numpy
-        array or a list of 1d numpy arrays.
+        The expanded digital conversion of the signal as a list of 1d numpy arrays.
     record_name : str, optional
         The name of the WFDB record to be read, without any file
         extensions. If the argument contains any path delimiter
@@ -2892,11 +2890,9 @@ def wrsamp(
         must be set, but not both. In addition, if d_signal is set, fmt, gain
         and baseline must also all be set.
     e_p_signal : ndarray, optional
-        The expanded physical conversion of the signal. Either a 2d numpy
-        array or a list of 1d numpy arrays.
+        The expanded physical conversion of the signal as a list of 1d numpy arrays.
     e_d_signal : ndarray, optional
-        The expanded digital conversion of the signal. Either a 2d numpy
-        array or a list of 1d numpy arrays.
+        The expanded digital conversion of the signal as a list of 1d numpy arrays.
     samps_per_frame : int or list of ints, optional
         The total number of samples per frame.
     fmt : list, optional


### PR DESCRIPTION
The docstrings for `e_p_signal` and `e_d_signal` incorrectly stated these could be either a 2D numpy array or a list of 1D numpy arrays. In practice, expanded signals are always stored as a list of 1D numpy arrays to support cases where different channels have different `samps_per_frame` values.