### PR TITLE
Remove unused import

### DIFF
--- a/wfdb/io/_header.py
+++ b/wfdb/io/_header.py
@@ -1,5 +1,4 @@
 import datetime
-from dateutil import parser
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np


### PR DESCRIPTION
This PR removes an import of from the `dateutil` package since it is not being used. The import had been added recently: https://github.com/MIT-LCP/wfdb-python/commit/5ec257e768289daa85af83ee614c40487f08dab6. 

From what I gather, this was the only place that `dateutil` was being used. Since `dateutil` was not in our `requirements.txt`, this could be related to the current issue where our readthedocs site is not displaying the docstring details. Hopefully this fixes the Read the Docs rendering issue. The build logs show that only section outlines were rendered because autodoc failed to import `wfdb` after hitting a now-removed, unused `dateutil` import that wasn’t installed in the docs build environment.