### PR TITLE
fix: guard against ZeroDivisionError in Comparitor._calc_stats

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -200,32 +200,40 @@ class test_qrs:
         assert comparitor.sensitivity > 0.99
         assert comparitor.positive_predictivity > 0.99
 
-    def test_compare_annotations_empty_ref(self):
-        """When reference annotations are empty, sensitivity should be NaN."""
-        import math
+    pass
 
-        comparitor = processing.compare_annotations(
-            np.array([]), np.array([10, 20, 30]), 5
-        )
-        assert math.isnan(comparitor.sensitivity)
-        assert comparitor.positive_predictivity == 0.0
 
-    def test_compare_annotations_empty_test(self):
-        """When test annotations are empty, PPV should be NaN."""
-        import math
+# Module-level tests for empty-annotation edge cases (pytest collects these
+# directly, unlike the lowercase class above which is skipped by default).
 
-        comparitor = processing.compare_annotations(
-            np.array([10, 20, 30]), np.array([]), 5
-        )
-        assert comparitor.sensitivity == 0.0
-        assert math.isnan(comparitor.positive_predictivity)
+def test_compare_annotations_empty_ref():
+    """When reference annotations are empty, sensitivity should be NaN."""
+    import math
 
-    def test_compare_annotations_both_empty(self):
-        """When both annotation arrays are empty, both metrics should be NaN."""
-        import math
+    comparitor = processing.compare_annotations(
+        np.array([]), np.array([10, 20, 30]), 5
+    )
+    assert math.isnan(comparitor.sensitivity)
+    assert comparitor.positive_predictivity == 0.0
 
-        comparitor = processing.compare_annotations(
-            np.array([]), np.array([]), 5
-        )
-        assert math.isnan(comparitor.sensitivity)
-        assert math.isnan(comparitor.positive_predictivity)
+
+def test_compare_annotations_empty_test():
+    """When test annotations are empty, PPV should be NaN."""
+    import math
+
+    comparitor = processing.compare_annotations(
+        np.array([10, 20, 30]), np.array([]), 5
+    )
+    assert comparitor.sensitivity == 0.0
+    assert math.isnan(comparitor.positive_predictivity)
+
+
+def test_compare_annotations_both_empty():
+    """When both annotation arrays are empty, both metrics should be NaN."""
+    import math
+
+    comparitor = processing.compare_annotations(
+        np.array([]), np.array([]), 5
+    )
+    assert math.isnan(comparitor.sensitivity)
+    assert math.isnan(comparitor.positive_predictivity)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -199,3 +199,33 @@ class test_qrs:
 
         assert comparitor.sensitivity > 0.99
         assert comparitor.positive_predictivity > 0.99
+
+    def test_compare_annotations_empty_ref(self):
+        """When reference annotations are empty, sensitivity should be NaN."""
+        import math
+
+        comparitor = processing.compare_annotations(
+            np.array([]), np.array([10, 20, 30]), 5
+        )
+        assert math.isnan(comparitor.sensitivity)
+        assert comparitor.positive_predictivity == 0.0
+
+    def test_compare_annotations_empty_test(self):
+        """When test annotations are empty, PPV should be NaN."""
+        import math
+
+        comparitor = processing.compare_annotations(
+            np.array([10, 20, 30]), np.array([]), 5
+        )
+        assert comparitor.sensitivity == 0.0
+        assert math.isnan(comparitor.positive_predictivity)
+
+    def test_compare_annotations_both_empty(self):
+        """When both annotation arrays are empty, both metrics should be NaN."""
+        import math
+
+        comparitor = processing.compare_annotations(
+            np.array([]), np.array([]), 5
+        )
+        assert math.isnan(comparitor.sensitivity)
+        assert math.isnan(comparitor.positive_predictivity)

--- a/wfdb/processing/evaluate.py
+++ b/wfdb/processing/evaluate.py
@@ -123,8 +123,11 @@ class Comparitor(object):
         self.fn = self.n_ref - self.tp
         # No tn attribute
 
-        self.sensitivity = float(self.tp) / float(self.tp + self.fn)
-        self.positive_predictivity = float(self.tp) / self.n_test
+        denom_sens = self.tp + self.fn
+        self.sensitivity = float(self.tp) / denom_sens if denom_sens > 0 else float("nan")
+        self.positive_predictivity = (
+            float(self.tp) / self.n_test if self.n_test > 0 else float("nan")
+        )
 
     def compare(self):
         """


### PR DESCRIPTION
## Summary

Guard against `ZeroDivisionError` when comparing annotations with empty reference or test arrays.

## Bug

`Comparitor._calc_stats()` divides `tp` by `(tp + fn)` for sensitivity and by `n_test` for positive predictivity without checking for zero denominators. When either annotation array is empty, this raises `ZeroDivisionError`.

## Fix

Return `float("nan")` when the denominator is zero, matching the convention used by `sklearn.metrics` for undefined ratios.

## Tests

Three module-level test functions covering all edge cases:
- Empty reference → sensitivity=NaN, PPV=0.0
- Empty test → sensitivity=0.0, PPV=NaN
- Both empty → both NaN

Fixes #278